### PR TITLE
Required for CLOB and BLOB.

### DIFF
--- a/src/models/database/columns.ts
+++ b/src/models/database/columns.ts
@@ -58,6 +58,7 @@ const databaseColumns: ReadonlyMap<DatabaseType, readonly ColumnType[]> = new Ma
         new ColumnType({ id: 1122, name: 'macaddr8', description: 'MAC (Media Access Control) アドレス (EUI-64 形式)', baseQuery: 'MACADDR8', withPrecision: false, withScale: false }),
         new ColumnType({ id: 9101, name: 'pg_lsn', description: 'PostgreSQLログシーケンス番号', baseQuery: 'PG_LSN', withPrecision: false, withScale: false }),
         new ColumnType({ id: 9102, name: 'pg_snapshot', description: 'ユーザレベルのトランザクションIDスナップショット', baseQuery: 'PG_SNAPSHOT', withPrecision: false, withScale: false }),
+        new ColumnType({ id: 9103, name: 'oid', description: 'オブジェクト識別子データ', baseQuery: 'OID', withPrecision: false, withScale: false}),
         ColumnType.EMPTY
     ]],
 


### PR DESCRIPTION
When registering large data exceeding 1GB in the database, an oid type column is used, so I would like it to be added.