### PR TITLE
Improve regal documents.

### DIFF
--- a/src/features/regal/PrivacyPolicyPanel.tsx
+++ b/src/features/regal/PrivacyPolicyPanel.tsx
@@ -28,6 +28,7 @@ const privacyPolicy = `
 本サービスは、利用者のデータやファイルを第三者に提供することは一切ありません。
 
 ## セキュリティ
+
 本サービスは、Google が提供する OAuth 2.0 認証を使用し、安全な通信経路（HTTPS）を通じてデータアクセスを行います。
 
 ## お問い合わせ
@@ -60,7 +61,6 @@ This Privacy Policy describes how the Service handles user data and files.
 
 - When used as a Google Drive App, the Service accesses only the files explicitly selected by the User via Google OAuth authorization.  
 - The accessed data is used solely for reading and saving ER diagrams.  
-- The Service does not send data to other Google services or external APIs.
 - When the Service is used outside of the Google Drive App, any data created by the User is stored solely on the User's local machine and is not saved on any Internet-connected servers.
 
 ## Data Storage

--- a/src/features/regal/TermsOfServicePanel.tsx
+++ b/src/features/regal/TermsOfServicePanel.tsx
@@ -35,7 +35,7 @@ const termsOfService = `
 
 - 本アプリケーションはオープンソースとして提供されており、コミュニティベースでの更新および改善が行われます。公式な商用サポートは提供しておりません。
 - 利用者は、利用に関する問題やバグレポート等については、GitHub のイシュー機能等を通じて報告してください。
-  - GitHub Issue ページ : https://github.com/kajitiluna/erd-designer/issues  
+  - GitHub Issue ページ : https://github.com/kajitiluna/erd-designer/issues
 - 上記において、開発者は報告された問題やバグレポート等を全て解決する義務は負いません。
 
 ## 個人情報等の取り扱い


### PR DESCRIPTION
Google ドライブアプリ向けの利用規約、およびプライバリーポリシーの文面を改善。(なぜか、以前審査がpassしたときから変更していないもかかわらず、更新時にリジェクトされたため)