### PR TITLE
feat: smooth wheel zoom and hide toolbars during scale gesture

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="src/logo.svg" alt="logo" width="200" style="display: block; margin: 20 auto;">
+<img src="images/icon.png" alt="logo" width="200" style="display: block; margin: 20 auto;">
 
 # Entity Relationship Diagram Designer
 

--- a/src/features/MainView.tsx
+++ b/src/features/MainView.tsx
@@ -8,6 +8,7 @@ import {
     SelectAction, reduceSelectAction, SelectEntityContext,
     EMPTY_SELECT_STATE, RELEASE_ACTION
 } from "~/context/SelectEntityContext";
+import { DRAWABLE_AREA } from "~/features/canvas/support";
 import ControlPanel from "~/features/canvas/ControlPanel";
 import DisplayScalePanel from "~/features/canvas/DisplayScalePanel";
 import ErdCanvas from "~/features/canvas/ErdCanvas";
@@ -27,6 +28,10 @@ type ErdDocumentsHolderOptions = {
     cursor: number
 };
 
+const MIN_SCALE = 0.05;
+const MAX_SCALE = 2;
+const ZOOM_SENSITIVITY = 0.002;
+
 const MainView = ({ erdDocument, onSave, erdExportable = true }: MainViewProps) => {
 
     const [holderProps, setHolderProps] = React.useState<ErdDocumentsHolderOptions>({ erdDocuments: [erdDocument], cursor: 0 });
@@ -34,6 +39,63 @@ const MainView = ({ erdDocument, onSave, erdExportable = true }: MainViewProps) 
     const [editMode, dispatchEditMode] = React.useReducer(initReduceEditMode(dispatchSelectAction), EditModeType.SELECT);
     const [localSetting, dispatchLocalSetting] = React.useReducer(reduceLocalSetting, DEFAULT_LOCAL_SETTING);
     const [scale, setScale] = React.useState<number>(1);
+    const scaleRef = React.useRef<number>(1);
+
+    const zoomTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
+
+    React.useEffect(() => {
+        scaleRef.current = scale;
+    }, [scale]);
+
+    React.useEffect(() => {
+        const handleWheel = (event: WheelEvent) => {
+            if (!event.ctrlKey && !event.metaKey) return;
+            event.preventDefault();
+            event.stopPropagation();
+
+            const oldScale = scaleRef.current;
+            const factor = Math.pow(2, -event.deltaY * ZOOM_SENSITIVITY);
+            const newScale = Math.min(MAX_SCALE, Math.max(MIN_SCALE, oldScale * factor));
+            if (newScale === oldScale) return;
+
+            const originX = DRAWABLE_AREA.width / 2;
+            const originY = DRAWABLE_AREA.height / 2;
+            const vw = window.innerWidth;
+            const vh = window.innerHeight;
+            const sx = window.scrollX;
+            const sy = window.scrollY;
+            const screenCenterCanvasX = sx + vw / 2;
+            const screenCenterCanvasY = sy + vh / 2;
+            const canvasPointX = (screenCenterCanvasX - originX * (1 - oldScale)) / oldScale;
+            const canvasPointY = (screenCenterCanvasY - originY * (1 - oldScale)) / oldScale;
+            const newScreenX = canvasPointX * newScale + originX * (1 - newScale) - vw / 2;
+            const newScreenY = canvasPointY * newScale + originY * (1 - newScale) - vh / 2;
+
+            scaleRef.current = newScale;
+
+            const canvas = document.getElementById("erd-canvas");
+            if (canvas) {
+                canvas.style.transform = `scale(${newScale})`;
+            }
+            const hideIds = ["toolbar-portal", "relation-toolbar-container"];
+            const hideElements = [
+                ...hideIds.map(id => document.getElementById(id)),
+                ...Array.from(document.querySelectorAll<HTMLElement>(".MuiPopover-root"))
+            ].filter(Boolean) as HTMLElement[];
+            hideElements.forEach(el => el.style.visibility = "hidden");
+            window.scrollTo(newScreenX, newScreenY);
+
+            if (zoomTimerRef.current) clearTimeout(zoomTimerRef.current);
+            zoomTimerRef.current = setTimeout(() => {
+                setScale(scaleRef.current);
+                hideElements.forEach(el => el.style.visibility = "");
+                zoomTimerRef.current = null;
+            }, 100);
+        };
+
+        window.addEventListener("wheel", handleWheel, { passive: false, capture: true });
+        return () => window.removeEventListener("wheel", handleWheel, { capture: true });
+    }, []);
 
     const handleOnSave = (documents: ErdDocument[], cursor: number, loggingMessage: string) => {
         if ((cursor < 0) || (cursor >= documents.length)) {

--- a/src/features/canvas/DisplayScalePanel.tsx
+++ b/src/features/canvas/DisplayScalePanel.tsx
@@ -7,6 +7,19 @@ type DisplayScalePanelProps = {
     onChangeScale: (updating: number) => void
 };
 
+const findNearestPresetIndex = (scale: number): number => {
+    let best = 0;
+    let bestDist = Math.abs(DISPLAY_SCALES[0] - scale);
+    for (let i = 1; i < DISPLAY_SCALES.length; i++) {
+        const dist = Math.abs(DISPLAY_SCALES[i] - scale);
+        if (dist < bestDist) {
+            best = i;
+            bestDist = dist;
+        }
+    }
+    return best;
+};
+
 const DisplayScalePanel = ({ scale, onChangeScale }: DisplayScalePanelProps) => {
 
     const handleChangeScale = (event: SelectChangeEvent<number>) => {
@@ -18,29 +31,22 @@ const DisplayScalePanel = ({ scale, onChangeScale }: DisplayScalePanelProps) => 
         onChangeScale(nextValue);
     };
 
-    const scaleIndex = DISPLAY_SCALES.indexOf(scale as typeof DISPLAY_SCALES[number]);
-    if (scaleIndex < 0) {
-        onChangeScale(1);
-        return (<></>);
-    }
+    const exactIndex = DISPLAY_SCALES.indexOf(scale as typeof DISPLAY_SCALES[number]);
+    const nearestIndex = exactIndex >= 0 ? exactIndex : findNearestPresetIndex(scale);
 
     const handleZoomOut = () => {
-        if (scaleIndex <= 0) {
-            return;
-        }
-
-        const nextScale = DISPLAY_SCALES[scaleIndex - 1];
-        onChangeScale(nextScale);
+        const targetIndex = exactIndex >= 0 ? exactIndex - 1 : Math.max(nearestIndex - 1, 0);
+        if (targetIndex < 0) return;
+        onChangeScale(DISPLAY_SCALES[targetIndex]);
     };
 
     const handleZoomIn = () => {
-        if (scaleIndex >= DISPLAY_SCALES.length - 1) {
-            return;
-        }
-
-        const nextScale = DISPLAY_SCALES[scaleIndex + 1];
-        onChangeScale(nextScale);
+        const targetIndex = exactIndex >= 0 ? exactIndex + 1 : Math.min(nearestIndex + 1, DISPLAY_SCALES.length - 1);
+        if (targetIndex >= DISPLAY_SCALES.length) return;
+        onChangeScale(DISPLAY_SCALES[targetIndex]);
     };
+
+    const customLabel = `${(scale * 100).toFixed(0)} %`;
 
     const panelStyle = {
         display: "flex",
@@ -61,20 +67,22 @@ const DisplayScalePanel = ({ scale, onChangeScale }: DisplayScalePanelProps) => 
         <Box sx={panelStyle}>
             <ButtonGroup orientation="horizontal" aria-label="horizontal button group" sx={buttonStyle}>
                 <IconButton aria-label="zoom out" size="small"
-                    disabled={scaleIndex <= 0} onClick={handleZoomOut}>
+                    disabled={nearestIndex <= 0 && exactIndex === 0} onClick={handleZoomOut}>
                     <ZoomOutIcon />
                 </IconButton>
                 <FormControl size="small" sx={{ width: "100px" }}>
-                    <Select id="select-display-scale" value={scale} onChange={handleChangeScale}>
+                    <Select id="select-display-scale" value={scale}
+                        renderValue={() => customLabel}
+                        onChange={handleChangeScale}>
                         {DISPLAY_SCALES
-                            .map(scale => initScaleInfo(scale))
-                            .map(scale => <MenuItem key={`select-scale-${scale.label}`} value={scale.value}>
-                                {scale.label}
+                            .map(s => initScaleInfo(s))
+                            .map(s => <MenuItem key={`select-scale-${s.label}`} value={s.value}>
+                                {s.label}
                             </MenuItem>)}
                     </Select>
                 </FormControl>
                 <IconButton aria-label="zoom in" size="small"
-                    disabled={scaleIndex >= DISPLAY_SCALES.length - 1} onClick={handleZoomIn}>
+                    disabled={nearestIndex >= DISPLAY_SCALES.length - 1 && exactIndex === DISPLAY_SCALES.length - 1} onClick={handleZoomIn}>
                     <ZoomInIcon />
                 </IconButton>
             </ButtonGroup>

--- a/src/features/canvas/ErdCanvas.tsx
+++ b/src/features/canvas/ErdCanvas.tsx
@@ -425,7 +425,7 @@ const ErdCanvas = () => {
 
             {grabbingPanel}
 
-            <div ref={toolbarPortalRef} style={{
+            <div id="toolbar-portal" ref={toolbarPortalRef} style={{
                 position: "absolute", top: 0, left: 0,
                 width: DRAWABLE_AREA.width, height: DRAWABLE_AREA.height,
                 pointerEvents: "none", zIndex: 200,
@@ -433,10 +433,12 @@ const ErdCanvas = () => {
                 transformOrigin: `${DRAWABLE_AREA.width / 2}px ${DRAWABLE_AREA.height / 2}px`
             }} />
 
-            <ErdRelationPathView ref={relationRef}
-                relationViews={erdDocument.getRelationViewModels()}
-                rectangleMap={rectangleArea.tableRectangles}
-                onEditAction={setEditAction} onDragAction={dispatchDragAction} />
+            <div id="relation-toolbar-container">
+                <ErdRelationPathView ref={relationRef}
+                    relationViews={erdDocument.getRelationViewModels()}
+                    rectangleMap={rectangleArea.tableRectangles}
+                    onEditAction={setEditAction} onDragAction={dispatchDragAction} />
+            </div>
 
             {initEditView(editAction, rectangleArea, handleCloseEditDialog)}
         </ToolbarPortalContext.Provider>


### PR DESCRIPTION
## Summary

- Add smooth Ctrl/Cmd+scroll wheel zoom at 60fps by directly manipulating DOM `style.transform`, with React state debounced at 100ms
- Hide all toolbars, connection menus, and MUI Popovers (color pickers, submenus) during the zoom gesture to prevent position drift, then show them when zoom settles
- Update `DisplayScalePanel` to handle non-preset scale values — shows custom percentage label, +/- buttons snap to nearest preset step

Closes #157

**Stacked on #162** — merge that first, then this PR's diff will be clean.

## Test plan

- [ ] Cmd+scroll zooms smoothly, centered on viewport
- [ ] Scale panel (bottom-right) shows current % even at non-preset values (e.g. "67 %")
- [ ] +/- buttons snap to nearest preset step from any custom zoom level
- [ ] Dropdown selection jumps to exact preset scale
- [ ] Table/memo/connection toolbars and any open popover hide during zoom, reappear correctly after
- [ ] No regressions from #162 (constant-size toolbars, correct positioning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)