### PR TITLE
fix: portal table and memo toolbars outside scaled canvas

### DIFF
--- a/src/context/ToolbarPortalContext.ts
+++ b/src/context/ToolbarPortalContext.ts
@@ -1,0 +1,5 @@
+import React from "react";
+
+const ToolbarPortalContext = React.createContext<React.RefObject<HTMLDivElement | null>>({ current: null });
+
+export default ToolbarPortalContext;

--- a/src/features/canvas/ErdCanvas.tsx
+++ b/src/features/canvas/ErdCanvas.tsx
@@ -28,6 +28,7 @@ import PerspectiveSettingView from "~/features/editor/PerspectiveSettingView";
 import RelationEditView from "~/features/editor/RelationEditView";
 import TableEditView from "~/features/editor/TableEditView";
 import StickyMemoView, { ERD_MEMO_VIEW_CLASS_NAME } from "~/features/canvas/StickyMemoView";
+import ToolbarPortalContext from "~/context/ToolbarPortalContext";
 
 type RectangleArea = {
     tableRectangles: Map<string, RectangleViewModel>,
@@ -36,6 +37,7 @@ type RectangleArea = {
 
 const ErdCanvas = () => {
     const erdCanvasRef = React.useRef<HTMLDivElement>(null);
+    const toolbarPortalRef = React.useRef<HTMLDivElement>(null);
     const [dragState, dispatchDragAction] = React.useReducer(reduceDragAction, NO_DRAGGING);
 
     const documentsHolder = React.useContext(ErdDocumentsHolderContext);
@@ -75,6 +77,8 @@ const ErdCanvas = () => {
     const tableViews = erdDocument.getTableViewModels().map(tableView => (
         <ErdTableView key={`erd-table-view_${tableView.tableId}`}
             tableViewModel={tableView}
+            tableWidth={rectangleArea.tableRectangles.get(tableView.tableId)?.width ?? 0}
+            tableHeight={rectangleArea.tableRectangles.get(tableView.tableId)?.height ?? 0}
             visible={(currentPerspective == null)
                 || currentPerspective.containsModel(tableView.tableId)}
             onEditAction={setEditAction}
@@ -395,6 +399,7 @@ const ErdCanvas = () => {
     return (
         <DragActionContext.Provider value={dragState}>
         <CanvasPositionContext.Provider value={positionResolver}>
+        <ToolbarPortalContext.Provider value={toolbarPortalRef}>
             <div id="erd-canvas" ref={erdCanvasRef} style={canvasStyle}
                 onClick={handleClickOnCanvas} onMouseMove={handleMoveMouseOnCanvas}
                 onMouseDown={handleDragStart} onMouseUp={handleDragEnd}>
@@ -420,12 +425,21 @@ const ErdCanvas = () => {
 
             {grabbingPanel}
 
+            <div ref={toolbarPortalRef} style={{
+                position: "absolute", top: 0, left: 0,
+                width: DRAWABLE_AREA.width, height: DRAWABLE_AREA.height,
+                pointerEvents: "none", zIndex: 200,
+                transform: `scale(${displayScale})`,
+                transformOrigin: `${DRAWABLE_AREA.width / 2}px ${DRAWABLE_AREA.height / 2}px`
+            }} />
+
             <ErdRelationPathView ref={relationRef}
                 relationViews={erdDocument.getRelationViewModels()}
                 rectangleMap={rectangleArea.tableRectangles}
                 onEditAction={setEditAction} onDragAction={dispatchDragAction} />
 
             {initEditView(editAction, rectangleArea, handleCloseEditDialog)}
+        </ToolbarPortalContext.Provider>
         </CanvasPositionContext.Provider>
         </DragActionContext.Provider>
     );

--- a/src/features/canvas/ErdTableView.tsx
+++ b/src/features/canvas/ErdTableView.tsx
@@ -1,8 +1,9 @@
 /* eslint-disable react-hooks/exhaustive-deps */
 import React from "react";
+import { createPortal } from "react-dom";
 import {
     Box, Button, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle, Grid2, IconButton,
-    Stack, Table, TableBody, TableCell, TableContainer, TableRow, Tooltip
+    Table, TableBody, TableCell, TableContainer, TableRow, Tooltip
 } from "@mui/material";
 import EditIcon from "@mui/icons-material/Edit";
 import DeleteIcon from "@mui/icons-material/Delete";
@@ -19,6 +20,7 @@ import EditModeContext from "~/context/EditModeContext";
 import { ErdDocumentsHolder, ErdDocumentsHolderContext } from "~/context/ErdDocumentsHolderContext";
 import { LocalSettingContext } from "~/context/LocalSettingContext";
 import { RELEASE_ACTION, SelectEntityContext, SelectState } from "~/context/SelectEntityContext";
+import ToolbarPortalContext from "~/context/ToolbarPortalContext";
 import DescriptionTooltip from "~/features/canvas/DescriptionTooltip";
 import EditAction from "~/features/canvas/EditAction";
 import CanvasPositionContext from "~/context/CanvasPositionContext";
@@ -44,12 +46,14 @@ export const ERD_TABLE_VIEW_CLASS_NAME = "erdTableView";
 
 type ErdTableViewProps = {
     tableViewModel: TableViewModel,
+    tableWidth: number,
+    tableHeight: number,
     visible?: boolean,
     onEditAction: (editAction: EditAction) => void,
     onDragAction: (dragAction: DragAction) => void
 };
 
-const ErdTableView = ({ tableViewModel, visible = true, onEditAction, onDragAction }: ErdTableViewProps) => {
+const ErdTableView = ({ tableViewModel, tableWidth, tableHeight, visible = true, onEditAction, onDragAction }: ErdTableViewProps) => {
     const documentsHolder: ErdDocumentsHolder = React.useContext(ErdDocumentsHolderContext);
     const { editMode } = React.useContext(EditModeContext);
     const { selectState } = React.useContext(SelectEntityContext);
@@ -92,6 +96,8 @@ const ErdTableView = ({ tableViewModel, visible = true, onEditAction, onDragActi
         return (
             <InnerErdTableView
                 tableViewModel={tableViewModel}
+                tableWidth={tableWidth}
+                tableHeight={tableHeight}
                 onEditAction={onEditAction}
                 onDragAction={onDragAction}
                 tableContentCache={tableContentCache}
@@ -336,6 +342,8 @@ type SelfSelectableMode = "none" | "start_selecting" | "self_selectable";
 
 type InnerErdTableViewProps = {
     tableViewModel: TableViewModel,
+    tableWidth: number,
+    tableHeight: number,
     onEditAction: (editAction: EditAction) => void,
     onDragAction: (dragAction: DragAction) => void,
     tableContentCache: React.JSX.Element,
@@ -346,7 +354,7 @@ type InnerErdTableViewProps = {
 };
 
 const InnerErdTableView = ({
-    tableViewModel, onEditAction, onDragAction,
+    tableViewModel, tableWidth, tableHeight, onEditAction, onDragAction,
     tableContentCache, selected, isOpenDeletingDialog, visible, onOpenDeleteDialog
 }: InnerErdTableViewProps) => {
 
@@ -551,36 +559,54 @@ const InnerErdTableView = ({
         `${ERD_TABLE_VIEW_CLASS_NAME} ${styleClasses.selectedBox}`
         : ERD_TABLE_VIEW_CLASS_NAME;
 
-    const controlPanel = (!selected || (editMode !== EditModeType.SELECT)
-        || (dragState.status === "on_dragging")
-        || (selectState.tableIds.size + selectState.memoIds.size !== 1))
-        ? (<></>) : (
-            <Stack direction="row" justifyContent="flex-end" onClick={handlePreventMouseEvent}
-                onMouseDown={handlePreventMouseEvent} onMouseUp={handlePreventMouseEvent}>
-                <div style={CONTROL_PANEL_STYLE}>
-                    <ColorSelector key={`table-color-selector_${tableViewModel.tableId}`}
-                        color={tableViewModel.headerColor.background}
-                        callback={handleSetColor} />
-                    {(perspectives.length > 0) && (
-                        <Tooltip title="Perspective" placement="top-end">
-                            <IconButton onClick={handleSettingPerspectiveDialog}>
-                                <VisibilityIcon />
-                            </IconButton>
-                        </Tooltip>
-                    )}
-                    <Tooltip title="Edit" placement="top-end">
-                        <IconButton onClick={handleOpenEditDialog}>
-                            <EditIcon />
+    const toolbarPortalRef = React.useContext(ToolbarPortalContext);
+
+    const showToolbar = selected && (editMode === EditModeType.SELECT)
+        && (dragState.status !== "on_dragging")
+        && (selectState.tableIds.size + selectState.memoIds.size === 1);
+
+    const counterScale = 1 / displayScale;
+
+    const controlPanel = (!showToolbar || !toolbarPortalRef.current) ? null : createPortal(
+        <div style={{
+            position: "absolute",
+            left: tableViewModel.corner.left + moving.x + DRAWABLE_AREA.width / 2,
+            top: tableViewModel.corner.top + moving.y + tableHeight + DRAWABLE_AREA.height / 2,
+            width: tableWidth,
+            display: "flex", justifyContent: "flex-end",
+            transform: `scale(${counterScale})`,
+            transformOrigin: "top right",
+            marginTop: 4,
+            pointerEvents: "auto",
+        }}
+        onClick={handlePreventMouseEvent}
+        onMouseDown={handlePreventMouseEvent}
+        onMouseUp={handlePreventMouseEvent}>
+            <div style={CONTROL_PANEL_STYLE}>
+                <ColorSelector key={`table-color-selector_${tableViewModel.tableId}`}
+                    color={tableViewModel.headerColor.background}
+                    callback={handleSetColor} />
+                {(perspectives.length > 0) && (
+                    <Tooltip title="Perspective" placement="top-end">
+                        <IconButton onClick={handleSettingPerspectiveDialog}>
+                            <VisibilityIcon />
                         </IconButton>
                     </Tooltip>
-                    <Tooltip title="Delete" placement="top-end">
-                        <IconButton onClick={() => onOpenDeleteDialog(true)}>
-                            <DeleteIcon />
-                        </IconButton>
-                    </Tooltip>
-                </div>
-            </Stack>
-        );
+                )}
+                <Tooltip title="Edit" placement="top-end">
+                    <IconButton onClick={handleOpenEditDialog}>
+                        <EditIcon />
+                    </IconButton>
+                </Tooltip>
+                <Tooltip title="Delete" placement="top-end">
+                    <IconButton onClick={() => onOpenDeleteDialog(true)}>
+                        <DeleteIcon />
+                    </IconButton>
+                </Tooltip>
+            </div>
+        </div>,
+        toolbarPortalRef.current
+    );
 
     return (
         <Box sx={tableStyle}>

--- a/src/features/canvas/ErdTableView.tsx
+++ b/src/features/canvas/ErdTableView.tsx
@@ -118,6 +118,8 @@ const ErdTableView = ({ tableViewModel, tableWidth, tableHeight, visible = true,
         tableContentCache,
         // 削除確認ダイアログ表示に対する検証
         openDeletingDialog,
+        // ポータルツールバーの位置に対する検証
+        tableWidth, tableHeight,
     ]);
 
     return viewCache;

--- a/src/features/canvas/StickyMemoView.tsx
+++ b/src/features/canvas/StickyMemoView.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { createPortal } from "react-dom";
 import {
     Box, Button, ButtonGroup, Dialog, DialogActions, DialogContent, DialogContentText, DialogTitle,
     Divider, FormControl, IconButton, MenuItem, Select, SelectChangeEvent, Stack, ToggleButton, Tooltip
@@ -16,6 +17,7 @@ import FormatAlignRightIcon from "@mui/icons-material/FormatAlignRight";
 import VisibilityIcon from '@mui/icons-material/Visibility';
 
 import ColorSelector from "~/components/ColorSelector";
+import ToolbarPortalContext from "~/context/ToolbarPortalContext";
 import DisplayScaleContext from "~/context/DisplayScaleContext";
 import { DragAction, DragActionContext } from "~/context/DragActionContext";
 import EditModeContext from "~/context/EditModeContext";
@@ -421,6 +423,8 @@ const StickyControlPane = ({ memoViewModel, onSettingAction }: StickyControlPane
     const documentsHolder: ErdDocumentsHolder = React.useContext(ErdDocumentsHolderContext);
     const { editMode } = React.useContext(EditModeContext);
     const { dispatchSelectAction } = React.useContext(SelectEntityContext);
+    const displayScale = React.useContext(DisplayScaleContext);
+    const toolbarPortalRef = React.useContext(ToolbarPortalContext);
     const { dispatchLocalSetting } = React.useContext(LocalSettingContext);
 
     const [showAlignPanel, setShowAlignPanel] = React.useState<boolean>(false);
@@ -586,52 +590,75 @@ const StickyControlPane = ({ memoViewModel, onSettingAction }: StickyControlPane
         </div>
     );
 
-    return (
-        <>
-            <Stack direction="row" alignItems="flex-start" justifyContent="flex-end" sx={{ marginTop: "10px" }}
-                onClick={handlePreventMouseEvent} onMouseDown={handlePreventMouseEvent}>
-                <div style={controlStyle}>
-                    <ColorSelector key={`memo-color-selector_${memoViewModel.memoId}`}
-                        color={memoViewModel.backgroundColor} callback={handleSetColor} />
-                    <FormControl size="small">
-                        <Select value={memoViewModel.fontSize} defaultValue={9}
-                            onChange={handleChangeFontSize}>
-                            {FONT_SIZES.map(fontSize => <MenuItem
-                                key={`select-fontsize_${memoViewModel.memoId}_${fontSize}`}
-                                value={fontSize}>
-                                {fontSize}
-                            </MenuItem>)}
-                        </Select>
-                    </FormControl>
-                    <div style={{ position: "relative", display: "inline-block" }}>
-                        <Tooltip title="Set align" placement="top-end">
-                            <ToggleButton size="small" selected={showAlignPanel} value="check"
-                                onChange={() => setShowAlignPanel(!showAlignPanel)}>
-                                <FormatAlignJustifyIcon />
-                            </ToggleButton>
-                        </Tooltip>
-                        {alignPanel}
-                    </div>
-                    {(perspectives.length > 0) && (
-                        <Tooltip title="Perspective" placement="top-end">
-                            <IconButton onClick={handleSettingPerspectiveDialog}>
-                                <VisibilityIcon />
-                            </IconButton>
-                        </Tooltip>
-                    )}
-                    <Tooltip title="To back" placement="top-end">
-                        <IconButton onClick={handleBackPosition}><FlipToBackIcon /></IconButton>
+    const rect = memoViewModel.rectangleViewModel;
+    const portalContainer = toolbarPortalRef.current;
+
+    if (!portalContainer) return <>{deleteDialog}</>;
+
+    const counterScale = 1 / displayScale;
+
+    const toolbar = createPortal(
+        <div style={{
+            position: "absolute",
+            left: rect.left + DRAWABLE_AREA.width / 2,
+            top: rect.top + rect.height + DRAWABLE_AREA.height / 2,
+            width: rect.width,
+            display: "flex", justifyContent: "flex-end",
+            transform: `scale(${counterScale})`,
+            transformOrigin: "top right",
+            marginTop: "4px",
+            pointerEvents: "auto",
+        }}
+        onClick={handlePreventMouseEvent}
+        onMouseDown={handlePreventMouseEvent}>
+            <div style={controlStyle}>
+                <ColorSelector key={`memo-color-selector_${memoViewModel.memoId}`}
+                    color={memoViewModel.backgroundColor} callback={handleSetColor} />
+                <FormControl size="small">
+                    <Select value={memoViewModel.fontSize} defaultValue={9}
+                        onChange={handleChangeFontSize}>
+                        {FONT_SIZES.map(fontSize => <MenuItem
+                            key={`select-fontsize_${memoViewModel.memoId}_${fontSize}`}
+                            value={fontSize}>
+                            {fontSize}
+                        </MenuItem>)}
+                    </Select>
+                </FormControl>
+                <div style={{ position: "relative", display: "inline-block" }}>
+                    <Tooltip title="Set align" placement="top-end">
+                        <ToggleButton size="small" selected={showAlignPanel} value="check"
+                            onChange={() => setShowAlignPanel(!showAlignPanel)}>
+                            <FormatAlignJustifyIcon />
+                        </ToggleButton>
                     </Tooltip>
-                    <Tooltip title="To front" placement="top-end">
-                        <IconButton onClick={handleFrontPosition}><FlipToFrontIcon /></IconButton>
-                    </Tooltip>
-                    <Tooltip title="Delete" placement="top-end">
-                        <IconButton onMouseDown={() => setOpenDeleteDialog(true)}>
-                            <DeleteIcon />
+                    {alignPanel}
+                </div>
+                {(perspectives.length > 0) && (
+                    <Tooltip title="Perspective" placement="top-end">
+                        <IconButton onClick={handleSettingPerspectiveDialog}>
+                            <VisibilityIcon />
                         </IconButton>
                     </Tooltip>
-                </div>
-            </Stack>
+                )}
+                <Tooltip title="To back" placement="top-end">
+                    <IconButton onClick={handleBackPosition}><FlipToBackIcon /></IconButton>
+                </Tooltip>
+                <Tooltip title="To front" placement="top-end">
+                    <IconButton onClick={handleFrontPosition}><FlipToFrontIcon /></IconButton>
+                </Tooltip>
+                <Tooltip title="Delete" placement="top-end">
+                    <IconButton onMouseDown={() => setOpenDeleteDialog(true)}>
+                        <DeleteIcon />
+                    </IconButton>
+                </Tooltip>
+            </div>
+        </div>,
+        portalContainer
+    );
+
+    return (
+        <>
+            {toolbar}
             {deleteDialog}
         </>
     );


### PR DESCRIPTION
## Summary

- Use `ReactDOM.createPortal()` to render table and memo toolbars into a container div **outside** the CSS-scaled `#erd-canvas`, so they stay constant visual size at all zoom levels
- Position toolbars using canvas-space coordinates within the portal div (which shares the same `transform: scale()` as the canvas), then counter-scale each toolbar with `scale(1/displayScale)`
- Add `ToolbarPortalContext` to share the portal container ref from `ErdCanvas` down to child components

Closes #161

## Test plan

- [ ] Select a table — toolbar appears below it at constant size across all zoom levels
- [ ] Select a memo — toolbar appears below it at constant size across all zoom levels  
- [ ] Select a relation — toolbar still works (no regression)
- [ ] Open color picker from any toolbar — positions correctly at different zoom levels
- [ ] Drag a table while selected — toolbar follows during drag
- [ ] Click empty canvas — all toolbars disappear

🤖 Generated with [Claude Code](https://claude.com/claude-code)