### PR TITLE
feat: relation label formatting toolbar and click-to-show toolbar fix

### DIFF
--- a/src/context/ErdDocumentsHolderContext.ts
+++ b/src/context/ErdDocumentsHolderContext.ts
@@ -8,7 +8,7 @@ import ColumnShareModel from "~/models/database/ColumnShareModel";
 import DbSchemaConfig from "~/models/DbSchemaConfig";
 import ErdDocument from "~/models/ErdDocument";
 import ErdSettingModel from "~/models/ErdSettingModel";
-import LineViewModel, { OrthogonalDirection } from "~/models/LineViewModel";
+import LineViewModel, { LabelStyle, OrthogonalDirection } from "~/models/LineViewModel";
 import MemoViewModel from "~/models/MemoViewModel";
 import RelationViewModel from "~/models/RelationViewModel";
 import TableViewModel from "~/models/TableViewModel";
@@ -285,6 +285,13 @@ export class ErdDocumentsHolder {
         this.doUpdateRelationEdge(
             loggingMessage,
             { relationId, updateFunction: (previous => previous.updateLabelPosition(position)) }
+        );
+    }
+
+    public updateRelationLabelStyle(relationId: string, style: LabelStyle, loggingMessage: string) {
+        this.doUpdateRelationEdge(
+            loggingMessage,
+            { relationId, updateFunction: (previous => previous.updateLabelStyle(style)) }
         );
     }
 

--- a/src/context/ErdDocumentsHolderContext.ts
+++ b/src/context/ErdDocumentsHolderContext.ts
@@ -281,6 +281,13 @@ export class ErdDocumentsHolder {
      * @param relationId リレーションID
      * @param edgeId 削除対象の Edge
      */
+    public updateRelationLabelPosition(relationId: string, position: { segment: number, fraction: number, dx: number, dy: number }, loggingMessage: string) {
+        this.doUpdateRelationEdge(
+            loggingMessage,
+            { relationId, updateFunction: (previous => previous.updateLabelPosition(position)) }
+        );
+    }
+
     public deleteRelationEdge(relationId: string, edgeId: number) {
         this.doUpdateRelationEdge(
             `Delete relation edge: ${JSON.stringify({ relationId, edgeId })}`,

--- a/src/context/LocalSettingContext.ts
+++ b/src/context/LocalSettingContext.ts
@@ -6,6 +6,7 @@ export type LocalSetting = {
     defaultColor: { background: ColorValue, foreground: ColorValue },
     perspectiveId: string,
     visibleLineStyle: "both-bounded" | "half-bounded",
+    showRelationNames: boolean,
     stickySize: { width: number, height: number },
     stickyFontSize: number
 };
@@ -14,6 +15,7 @@ export type LocalSettingAction =
     { type: "defaultColor", color: { background: ColorValue, foreground: ColorValue } }
     | { type: "perspective", perspectiveId: string }
     | { type: "showLine", visibleStyle: "both-bounded" | "half-bounded" }
+    | { type: "showRelationNames", show: boolean }
     | { type: "stickySize", size: { width: number, height: number } }
     | { type: "stickyFontSize", fontSize: number };
 
@@ -43,6 +45,14 @@ export const reduceLocalSetting = (current: LocalSetting, action: LocalSettingAc
         return { ...current, visibleLineStyle: action.visibleStyle };
     }
 
+    if (action.type === "showRelationNames") {
+        if (current.showRelationNames === action.show) {
+            return current;
+        }
+
+        return { ...current, showRelationNames: action.show };
+    }
+
     if (action.type === "stickySize") {
         if ((current.stickySize.width === action.size.width)
             && (current.stickySize.height === action.size.height)) {
@@ -70,6 +80,7 @@ export const DEFAULT_LOCAL_SETTING: LocalSetting = {
     },
     perspectiveId: "",
     visibleLineStyle: "both-bounded",
+    showRelationNames: false,
     stickySize: { width: 100, height: 100 },
     stickyFontSize: 9
 };

--- a/src/context/SelectEntityContext.ts
+++ b/src/context/SelectEntityContext.ts
@@ -14,12 +14,14 @@ export type SelectAction = { type: "none" }
     | SelectMemoAction
     | SelectBulkAction
     | SelectEdgeAction
+    | SelectRelationAction
     | { type: "completed" };
 
 type SelectTableAction = { type: "table", tableId: string, withMultiSelection?: boolean };
 type SelectMemoAction = { type: "memo", memoId: string, withMultiSelection?: boolean };
 type SelectBulkAction = { type: "bulk", tableIds: string[], memoIds: string[], withMultiSelection: boolean };
 type SelectEdgeAction = { type: "edge", lineType: "real" | "virtual", relationId: string, edgeId: number };
+type SelectRelationAction = { type: "relation", relationId: string };
 
 const EMPTY_IDS = new Set<string>();
 export const EMPTY_SELECT_STATE: SelectState = {
@@ -53,6 +55,10 @@ export const reduceSelectAction = (currentStatus: SelectState, action: SelectAct
 
     if (action.type === "edge") {
         return handleSelectEdge(action);
+    }
+
+    if (action.type === "relation") {
+        return { status: "selected", tableIds: EMPTY_IDS, memoIds: EMPTY_IDS, relationId: action.relationId };
     }
 
     return currentStatus;

--- a/src/features/MainView.tsx
+++ b/src/features/MainView.tsx
@@ -44,6 +44,12 @@ const MainView = ({ erdDocument, onSave, erdExportable = true }: MainViewProps) 
     const zoomTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
 
     React.useEffect(() => {
+        if (erdDocument.erdSettingModel.showRelationNames) {
+            dispatchLocalSetting({ type: "showRelationNames", show: true });
+        }
+    }, []);
+
+    React.useEffect(() => {
         scaleRef.current = scale;
     }, [scale]);
 

--- a/src/features/canvas/ControlPanel.tsx
+++ b/src/features/canvas/ControlPanel.tsx
@@ -21,6 +21,7 @@ import KeyboardArrowUpIcon from '@mui/icons-material/KeyboardArrowUp';
 import KeyboardArrowDownIcon from '@mui/icons-material/KeyboardArrowDown';
 import ExportDdlView from "~/features/editor/ExportDdlView";
 import download from "~/components/file-downloader";
+import PerspectiveModel from "~/models/PerspectiveModel";
 import { ErdDocumentsHolder, ErdDocumentsHolderContext } from "~/context/ErdDocumentsHolderContext";
 import { ERD_TABLE_VIEW_CLASS_NAME } from "~/features/canvas/ErdTableView";
 import { RELEASE_ACTION, SelectEntityContext } from "~/context/SelectEntityContext";
@@ -163,6 +164,26 @@ const ActionPanel = () => {
         </FormControl>
     );
 
+    const handleChangeShowRelationNames = (event: React.ChangeEvent<HTMLInputElement>) => {
+        const show = event.target.checked;
+        dispatchLocalSetting({ type: "showRelationNames", show });
+        const nextSetting = erdDocument.erdSettingModel.update({ showRelationNames: show });
+        documentsHolder.updateErdSetting(nextSetting, `Update show relation names: ${show}`);
+    };
+
+    const relationNameSwitcher = (
+        <FormControl sx={{ padding: "0 6px 6px 12px" }}>
+            <DescriptionTooltip placement="right-end"
+                title={"Show relation names as labels\non connection lines."}>
+                <FormControlLabel sx={SWITCH_FORM_STYLE}
+                    label="Show relation names" control={
+                        <Switch size="small" checked={localSetting.showRelationNames}
+                            onChange={handleChangeShowRelationNames} />
+                    } />
+            </DescriptionTooltip>
+        </FormControl>
+    );
+
     const handleSetDefaultColor = (background: ColorValue, foreground: ColorValue) => {
         dispatchLocalSetting({
             type: "defaultColor",
@@ -177,6 +198,7 @@ const ActionPanel = () => {
 
             {perspectiveSelector}
             {lineVisibleSwitcher}
+            {relationNameSwitcher}
             <Divider />
 
             <Button variant="text" startIcon={<UndoIcon />}
@@ -213,20 +235,67 @@ type SubMenuButtonProps = {
 
 const SubMenuPanel = ({ erdExportable }: SubMenuButtonProps) => {
     const { dispatchSelectAction } = React.useContext(SelectEntityContext);
+    const { dispatchLocalSetting } = React.useContext(LocalSettingContext);
     const [configureElement, setConfigureElement] = React.useState<HTMLElement | null>();
     const [selectedMenu, setSelectedMenu] = React.useState<"export_ddl" | "">("");
+    const [batchExportQueue, setBatchExportQueue] = React.useState<PerspectiveModel[]>([]);
     const { exportSpecification } = React.useContext(ExportSpecificationContext);
 
     const documentsHolder: ErdDocumentsHolder = React.useContext(ErdDocumentsHolderContext);
     const erdDocument: ErdDocument = documentsHolder.current();
 
+    React.useEffect(() => {
+        if (batchExportQueue.length === 0) {
+            return;
+        }
+
+        const timer = setTimeout(() => {
+            const erdCanvas = document.getElementById("erd-canvas");
+            if (erdCanvas == null) {
+                setBatchExportQueue([]);
+                return;
+            }
+
+            const current = batchExportQueue[0];
+            const remaining = batchExportQueue.slice(1);
+
+            exportDiagramImage(erdCanvas, (contents: ImageContent) => {
+                const fileName = `${erdDocument.documentName} - ${current.perspectiveName}.png`;
+                download(fileName, contents.base64Value);
+
+                if (remaining.length > 0) {
+                    dispatchLocalSetting({ type: "perspective", perspectiveId: remaining[0].perspectiveId });
+                    setBatchExportQueue(remaining);
+                } else {
+                    dispatchLocalSetting({ type: "perspective", perspectiveId: "" });
+                    setBatchExportQueue([]);
+                }
+            });
+        }, 500);
+
+        return () => clearTimeout(timer);
+    }, [batchExportQueue, erdDocument, dispatchLocalSetting]);
+
     const handleOpenMenu = (event: React.MouseEvent<HTMLButtonElement>) => setConfigureElement(event.currentTarget);
 
     const handleSaveAsImage = () => {
-        // 出力画像に一部のエンティティが選択状態で描画されないよう、選択状態を解除する
         dispatchSelectAction(RELEASE_ACTION);
 
         downloadImage(erdDocument);
+        handleCloseMenu();
+    };
+
+    const handleBatchExportPerspectives = () => {
+        dispatchSelectAction(RELEASE_ACTION);
+
+        const perspectives = erdDocument.erdSettingModel.getPerspectiveModels();
+        if (perspectives.length === 0) {
+            handleCloseMenu();
+            return;
+        }
+
+        dispatchLocalSetting({ type: "perspective", perspectiveId: perspectives[0].perspectiveId });
+        setBatchExportQueue(perspectives);
         handleCloseMenu();
     };
 
@@ -262,6 +331,10 @@ const SubMenuPanel = ({ erdExportable }: SubMenuButtonProps) => {
                 slotProps={{ paper: { 'aria-labelledby': 'basic-button', } }}>
                 <MenuItem onClick={() => setSelectedMenu("export_ddl")}>Export DDL</MenuItem>
                 <MenuItem onClick={handleSaveAsImage}>Save as image</MenuItem>
+                <MenuItem onClick={handleBatchExportPerspectives}
+                    disabled={erdDocument.erdSettingModel.getPerspectiveModels().length === 0}>
+                    Export all perspectives as images
+                </MenuItem>
                 <MenuItem onClick={handleExportSpecification}>Export specification</MenuItem>
                 {erdExportable && <MenuItem onClick={handleSaveToJson}>Save to ERD file</MenuItem>}
             </Menu>

--- a/src/features/canvas/ErdCanvas.tsx
+++ b/src/features/canvas/ErdCanvas.tsx
@@ -448,9 +448,7 @@ const ErdCanvas = () => {
             <div id="toolbar-portal" ref={toolbarPortalRef} style={{
                 position: "absolute", top: 0, left: 0,
                 width: DRAWABLE_AREA.width, height: DRAWABLE_AREA.height,
-                pointerEvents: "none", zIndex: 200,
-                transform: `scale(${displayScale})`,
-                transformOrigin: `${DRAWABLE_AREA.width / 2}px ${DRAWABLE_AREA.height / 2}px`
+                pointerEvents: "none", zIndex: 200
             }} />
 
             <div id="relation-toolbar-container">

--- a/src/features/canvas/ErdCanvas.tsx
+++ b/src/features/canvas/ErdCanvas.tsx
@@ -22,7 +22,8 @@ import {
     getScroll, toNextOrthogonalLines, withMultiSelectKey
 } from "~/features/canvas/support";
 import EditAction from "~/features/canvas/EditAction";
-import ErdRelationPathView, { ErdRelationTooltipRef } from "~/features/canvas/ErdRelationPathView";
+import ErdRelationPathView, { ErdRelationTooltipRef, RelationLabelData } from "~/features/canvas/ErdRelationPathView";
+import RelationLabelOverlay from "~/features/canvas/RelationLabelOverlay";
 import ErdTableView, { ERD_TABLE_VIEW_CLASS_NAME } from "~/features/canvas/ErdTableView";
 import PerspectiveSettingView from "~/features/editor/PerspectiveSettingView";
 import RelationEditView from "~/features/editor/RelationEditView";
@@ -54,6 +55,7 @@ const ErdCanvas = () => {
     const relationRef = React.useRef<ErdRelationTooltipRef>(null);
     // リレーション等の線情報を保持する
     const [svgPaths, setSvgPaths] = React.useState<React.JSX.Element[]>([]);
+    const [relationLabels, setRelationLabels] = React.useState<RelationLabelData[]>([]);
     // 編集中の対象
     const [editAction, setEditAction] = React.useState<EditAction>(NO_EDIT_ACTION);
     // リレーション作成にて親テーブルが指定されているときに、論理的なマウス位置を保持する
@@ -320,7 +322,11 @@ const ErdCanvas = () => {
 
         const svgPaths = targetElements.map(element => element.path);
         setSvgPaths(svgPaths);
-    }, [selectState, dragState, rectangleArea, localSetting.visibleLineStyle, erdDocument, currentPerspective]);
+
+        if (relationRef.current != null) {
+            setRelationLabels(relationRef.current.labelData());
+        }
+    }, [selectState, dragState, rectangleArea, localSetting.visibleLineStyle, localSetting.showRelationNames, erdDocument, currentPerspective]);
 
     // マウスカーソルのアイコン設定
     React.useLayoutEffect(() => {
@@ -421,6 +427,20 @@ const ErdCanvas = () => {
                 {frontMemoViews}
 
                 <ActiveDraggingArea editMode={editMode} dragState={dragState} selectState={selectState} />
+
+                {localSetting.showRelationNames && (
+                    <div style={{
+                        position: "absolute", top: 0, left: 0,
+                        width: DRAWABLE_AREA.width, height: DRAWABLE_AREA.height,
+                        pointerEvents: "none", zIndex: 10000
+                    }}>
+                        {relationLabels.map(label => (
+                            <RelationLabelOverlay key={`relation-label-overlay_${label.relationView.relationId}`}
+                                labelData={label}
+                                selected={selectState.relationId === label.relationView.relationId} />
+                        ))}
+                    </div>
+                )}
             </div>
 
             {grabbingPanel}

--- a/src/features/canvas/ErdRelationPathView.tsx
+++ b/src/features/canvas/ErdRelationPathView.tsx
@@ -56,7 +56,7 @@ const ErdRelationPathView = ({ relationViews, rectangleMap, onEditAction, onDrag
     const dragState = React.useContext(DragActionContext);
     const displayScale = React.useContext(DisplayScaleContext);
 
-    const [clickedPosition, setClickedPosition] = React.useState<{ x: number, y: number }>({ x: 0, y: 0 });
+    const [clickedPosition, setClickedPosition] = React.useState<{ x: number, y: number } | null>(null);
     const [deletingRelation, setDeletingRelation] = React.useState<RelationViewModel | null>(null);
     const [lineEditElement, setLineEditElement] = React.useState<HTMLElement | null>(null);
 
@@ -100,6 +100,8 @@ const ErdRelationPathView = ({ relationViews, rectangleMap, onEditAction, onDrag
     const tooltip = relationViews.map(relationView => {
         if (
             (selectState.relationId !== relationView.relationId)
+            || (selectState.edgeType == null)
+            || (clickedPosition == null)
             || (editMode !== EditModeType.SELECT)
             || (dragState.status === "on_dragging")
         ) {
@@ -199,8 +201,8 @@ const ErdRelationPathView = ({ relationViews, rectangleMap, onEditAction, onDrag
                 onMouseDown={handlePreventMouseEvent} onMouseUp={handlePreventMouseEvent}
                 sx={{
                     position: "absolute",
-                    left: clickedPosition.x * displayScale + 15 + DRAWABLE_AREA.width / 2,
-                    top: clickedPosition.y * displayScale - 45 + DRAWABLE_AREA.height / 2,
+                    left: clickedPosition!.x * displayScale + 15 + DRAWABLE_AREA.width / 2,
+                    top: clickedPosition!.y * displayScale - 45 + DRAWABLE_AREA.height / 2,
                     backgroundColor: "#FFFFFF"
                 }}>
                 <ColorSelector key={`relation-color-selector_${relationView.relationId}`}
@@ -277,7 +279,7 @@ type Point = { x: number, y: number };
 
 const useStraightLineView = (
     relationViews: RelationViewModel[], rectangleMap: Map<string, RectangleViewModel>,
-    setClickedPosition: (position: { x: number, y: number }) => void,
+    setClickedPosition: (position: { x: number, y: number } | null) => void,
     handleOpenEditDialog: (event: React.MouseEvent, relationView: RelationViewModel) => void,
     onDragAction: (dragAction: DragAction) => void
 ) => {
@@ -419,6 +421,7 @@ const useStraightLineView = (
 
             event.stopPropagation();
 
+            setClickedPosition(null);
             const mousePosition = positionResolver.getLogicalPosition(event, displayScale);
 
             dispatchSelectAction({
@@ -459,7 +462,11 @@ const useStraightLineView = (
             event.stopPropagation();
 
             const mousePosition = positionResolver.getLogicalPosition(event, displayScale);
-            setClickedPosition(mousePosition);
+            const didDrag = dragState.status === "on_dragging"
+                && (dragState.delta().x !== 0 || dragState.delta().y !== 0);
+            if (!didDrag) {
+                setClickedPosition(mousePosition);
+            }
 
             setLineDragging({ on_dragging: false });
             onDragAction({ type: "clear" });
@@ -532,6 +539,7 @@ const useStraightLineView = (
                 return;
             }
 
+            setClickedPosition(null);
             const mousePosition = positionResolver.getLogicalPosition(event, displayScale);
 
             dispatchSelectAction({
@@ -756,7 +764,7 @@ const initOrthogonalLine = (
 
 const useOrthogonalLine = (
     relationViews: RelationViewModel[], rectangleMap: Map<string, RectangleViewModel>,
-    setClickedPosition: (position: { x: number, y: number }) => void,
+    setClickedPosition: (position: { x: number, y: number } | null) => void,
     handleOpenEditDialog: (event: React.MouseEvent, relationView: RelationViewModel) => void,
     onDragAction: (dragAction: DragAction) => void
 ) => {
@@ -814,6 +822,7 @@ const useOrthogonalLine = (
 
                 event.stopPropagation();
 
+                setClickedPosition(null);
                 const mousePosition = positionResolver.getLogicalPosition(event, displayScale);
 
                 dispatchSelectAction({
@@ -834,7 +843,11 @@ const useOrthogonalLine = (
                 event.stopPropagation();
 
                 const mousePosition = positionResolver.getLogicalPosition(event, displayScale);
-                setClickedPosition(mousePosition);
+                const didDrag = dragState.status === "on_dragging"
+                    && (dragState.delta().x !== 0 || dragState.delta().y !== 0);
+                if (!didDrag) {
+                    setClickedPosition(mousePosition);
+                }
 
                 onDragAction({ type: "clear" });
             };

--- a/src/features/canvas/ErdRelationPathView.tsx
+++ b/src/features/canvas/ErdRelationPathView.tsx
@@ -31,8 +31,14 @@ import {
 import EditAction from "~/features/canvas/EditAction";
 import styleClasses from "./ErdCanvas.module.css";
 
+export type RelationLabelData = {
+    relationView: RelationViewModel,
+    pathPoints: { x: number, y: number }[]
+};
+
 export type ErdRelationTooltipRef = {
-    svgElements: () => { tableIds: string[], path: React.JSX.Element }[]
+    svgElements: () => { tableIds: string[], path: React.JSX.Element }[],
+    labelData: () => RelationLabelData[]
 };
 
 type ErdRelationPathViewProps = {
@@ -222,7 +228,8 @@ const ErdRelationPathView = ({ relationViews, rectangleMap, onEditAction, onDrag
 
     React.useImperativeHandle(ref, () => {
         return {
-            svgElements: () => [...straightLinePaths, ...orthogonalLinePaths]
+            svgElements: () => [...straightLinePaths, ...orthogonalLinePaths],
+            labelData: () => [...straightLinePaths, ...orthogonalLinePaths].map(e => e.label)
         };
     }, [straightLinePaths, orthogonalLinePaths]);
 
@@ -379,7 +386,23 @@ const useStraightLineView = (
         const drawingPath = `M ${parentEdge.x + DRAWABLE_AREA.width / 2},${parentEdge.y + DRAWABLE_AREA.height / 2}`
             + relationLineSegments.map(lineSegment => lineSegment.drawingLine).join(" ");
 
-        return { svgPaths, drawingPath };
+        const labelEdges = [...relationEdges];
+        if (selectState.relationId === relationView.relationId
+            && dragState.status === "on_dragging"
+            && selectState.edgeId != null) {
+            if (selectState.edgeType === "real") {
+                const edgeIndex = selectState.edgeId + 1;
+                if (edgeIndex >= 0 && edgeIndex < labelEdges.length) {
+                    labelEdges[edgeIndex] = dragState.current;
+                }
+            } else if (selectState.edgeType === "virtual"
+                && lineDragging.on_dragging && lineDragging.majorChanging) {
+                const insertIndex = selectState.edgeId + 1;
+                labelEdges.splice(insertIndex, 0, dragState.current);
+            }
+        }
+
+        return { svgPaths, drawingPath, relationEdges, labelEdges };
     };
 
     // 操作対象の元となる線分 (透過) を作成する
@@ -652,7 +675,8 @@ const useStraightLineView = (
                         className={initPathCss(relationView, selected)} />
                     {lineSegment.svgPaths}
                 </g>
-            )
+            ),
+            label: { relationView, pathPoints: lineSegment.labelEdges } as RelationLabelData
         };
     }).filter(element => (element != null));
 };
@@ -858,7 +882,8 @@ const useOrthogonalLine = (
                         className={initPathCss(selected, isReducedLine)} />
                     {handlePaths}
                 </g>
-            )
+            ),
+            label: { relationView, pathPoints: draggedPoints } as RelationLabelData
         };
     }).filter(element => (element != null));
 };

--- a/src/features/canvas/ErdTableView.tsx
+++ b/src/features/canvas/ErdTableView.tsx
@@ -369,6 +369,8 @@ const InnerErdTableView = ({
     const positionResolver = React.useContext(CanvasPositionContext);
 
     const [selfSelectableMode, setSelfSelectableMode] = React.useState<SelfSelectableMode>("none");
+    const [toolbarVisible, setToolbarVisible] = React.useState(false);
+    const didDragRef = React.useRef(false);
 
     const erdDocument = documentsHolder.current();
     const erdSetting = erdDocument.erdSettingModel;
@@ -386,6 +388,8 @@ const InnerErdTableView = ({
         if (editMode === EditModeType.SELECT) {
             event.stopPropagation();
 
+            setToolbarVisible(false);
+            didDragRef.current = false;
             setSelfSelectableMode("none");
             onDragAction({ type: "start_dragging", start: mousePosition });
 
@@ -424,6 +428,13 @@ const InnerErdTableView = ({
         }
 
         if (editMode === EditModeType.SELECT) {
+            const didDrag = dragState.status === "on_dragging"
+                && (dragState.delta().x !== 0 || dragState.delta().y !== 0);
+            if (didDrag) {
+                didDragRef.current = true;
+                return;
+            }
+
             if ((selectState.status === "on_selecting")
                 && (selectState.tableIds.has(tableViewModel.tableId))) {
                 dispatchSelectAction({ type: "completed" });
@@ -480,6 +491,10 @@ const InnerErdTableView = ({
             return;
         }
 
+        if (!didDragRef.current) {
+            setToolbarVisible(true);
+        }
+        didDragRef.current = false;
         event.stopPropagation();
     };
 
@@ -563,22 +578,20 @@ const InnerErdTableView = ({
 
     const toolbarPortalRef = React.useContext(ToolbarPortalContext);
 
-    const showToolbar = selected && (editMode === EditModeType.SELECT)
+    if (!selected && toolbarVisible) {
+        setToolbarVisible(false);
+    }
+
+    const showToolbar = toolbarVisible && selected && (editMode === EditModeType.SELECT)
         && (dragState.status !== "on_dragging")
         && (selectState.tableIds.size + selectState.memoIds.size === 1);
-
-    const counterScale = 1 / displayScale;
 
     const controlPanel = (!showToolbar || !toolbarPortalRef.current) ? null : createPortal(
         <div style={{
             position: "absolute",
-            left: tableViewModel.corner.left + moving.x + DRAWABLE_AREA.width / 2,
-            top: tableViewModel.corner.top + moving.y + tableHeight + DRAWABLE_AREA.height / 2,
-            width: tableWidth,
-            display: "flex", justifyContent: "flex-end",
-            transform: `scale(${counterScale})`,
-            transformOrigin: "top right",
-            marginTop: 4,
+            left: (tableViewModel.corner.left + moving.x + tableWidth) * displayScale + DRAWABLE_AREA.width / 2,
+            top: (tableViewModel.corner.top + moving.y + tableHeight) * displayScale + DRAWABLE_AREA.height / 2 + 4,
+            transform: "translateX(-100%)",
             pointerEvents: "auto",
         }}
         onClick={handlePreventMouseEvent}

--- a/src/features/canvas/RelationLabelOverlay.tsx
+++ b/src/features/canvas/RelationLabelOverlay.tsx
@@ -1,10 +1,25 @@
 import React from "react";
+import { createPortal } from "react-dom";
+import { IconButton, Tooltip } from "@mui/material";
+import FormatBoldIcon from "@mui/icons-material/FormatBold";
+import FormatItalicIcon from "@mui/icons-material/FormatItalic";
+import StrikethroughSIcon from "@mui/icons-material/StrikethroughS";
+import AddIcon from "@mui/icons-material/Add";
+import RemoveIcon from "@mui/icons-material/Remove";
 
 import { ErdDocumentsHolder, ErdDocumentsHolderContext } from "~/context/ErdDocumentsHolderContext";
 import DisplayScaleContext from "~/context/DisplayScaleContext";
 import CanvasPositionContext from "~/context/CanvasPositionContext";
+import ToolbarPortalContext from "~/context/ToolbarPortalContext";
+import { SelectEntityContext } from "~/context/SelectEntityContext";
+import { DragActionContext } from "~/context/DragActionContext";
+import EditModeContext from "~/context/EditModeContext";
+import { EditModeType } from "~/models/EditMode";
+import ColorValue from "~/models/ColorValue";
+import { LabelStyle } from "~/models/LineViewModel";
+import ColorSelector from "~/components/ColorSelector";
 import { RelationLabelData } from "~/features/canvas/ErdRelationPathView";
-import { DRAWABLE_AREA } from "~/features/canvas/support";
+import { DRAWABLE_AREA, handlePreventMouseEvent } from "~/features/canvas/support";
 
 type Point = { x: number, y: number };
 
@@ -69,7 +84,13 @@ const RelationLabelOverlay = ({ labelData, selected }: RelationLabelOverlayProps
     const documentsHolder: ErdDocumentsHolder = React.useContext(ErdDocumentsHolderContext);
     const displayScale = React.useContext(DisplayScaleContext);
     const positionResolver = React.useContext(CanvasPositionContext);
+    const toolbarPortalRef = React.useContext(ToolbarPortalContext);
+    const { editMode } = React.useContext(EditModeContext);
+    const { selectState, dispatchSelectAction } = React.useContext(SelectEntityContext);
+    const dragState = React.useContext(DragActionContext);
     const labelRef = React.useRef<HTMLDivElement>(null);
+    const didDragRef = React.useRef(false);
+    const [toolbarVisible, setToolbarVisible] = React.useState(false);
     const stableAnchorRef = React.useRef<Point | null>(null);
     const prevPointCountRef = React.useRef(0);
     const reanchorRef = React.useRef<{ segment: number, fraction: number, dx: number, dy: number } | null>(null);
@@ -139,16 +160,21 @@ const RelationLabelOverlay = ({ labelData, selected }: RelationLabelOverlayProps
         })()
         : null;
 
+    const labelStyle: LabelStyle = relationView.lineViewModel.labelStyle;
+
     const handleMouseDown = (event: React.MouseEvent) => {
         if (event.button !== 0) return;
         event.stopPropagation();
 
+        setToolbarVisible(false);
+        didDragRef.current = false;
         const startPos = positionResolver.getLogicalPosition(event, displayScale);
         const startLabel = { x: labelX, y: labelY };
 
         setIsDragging(true);
 
         const handleMouseMove = (moveEvent: MouseEvent) => {
+            didDragRef.current = true;
             const movePos = positionResolver.getLogicalPosition(moveEvent as unknown as React.MouseEvent, displayScale);
             setDragPos({
                 x: startLabel.x + movePos.x - startPos.x,
@@ -181,11 +207,133 @@ const RelationLabelOverlay = ({ labelData, selected }: RelationLabelOverlayProps
         window.addEventListener("mouseup", handleMouseUp);
     };
 
+    const handleClick = (event: React.MouseEvent) => {
+        if (didDragRef.current) {
+            didDragRef.current = false;
+            return;
+        }
+        event.stopPropagation();
+        setToolbarVisible(true);
+        dispatchSelectAction({ type: "relation", relationId: relationView.relationId });
+    };
+
+    const handleToggleBold = () => {
+        const next = { ...labelStyle, bold: !labelStyle.bold };
+        documentsHolder.updateRelationLabelStyle(
+            relationView.relationId, next,
+            `Update label style: ${relationView.relationId}`
+        );
+    };
+
+    const handleToggleItalic = () => {
+        const next = { ...labelStyle, italic: !labelStyle.italic };
+        documentsHolder.updateRelationLabelStyle(
+            relationView.relationId, next,
+            `Update label style: ${relationView.relationId}`
+        );
+    };
+
+    const handleToggleStrikethrough = () => {
+        const next = { ...labelStyle, strikethrough: !labelStyle.strikethrough };
+        documentsHolder.updateRelationLabelStyle(
+            relationView.relationId, next,
+            `Update label style: ${relationView.relationId}`
+        );
+    };
+
+    const handleFontSizeChange = (delta: number) => {
+        const next = { ...labelStyle, fontSize: Math.max(1, labelStyle.fontSize + delta) };
+        documentsHolder.updateRelationLabelStyle(
+            relationView.relationId, next,
+            `Update label style: ${relationView.relationId}`
+        );
+    };
+
+    const handleSetColor = (background: ColorValue) => {
+        const hex = background.toHex();
+        const next = { ...labelStyle, color: hex === "#3c3c3c" ? undefined : hex };
+        documentsHolder.updateRelationLabelStyle(
+            relationView.relationId, next,
+            `Update label style: ${relationView.relationId}`
+        );
+    };
+
     const projDotLeft = anchorProjection ? anchorProjection.x + DRAWABLE_AREA.width / 2 : 0;
     const projDotTop = anchorProjection ? anchorProjection.y + DRAWABLE_AREA.height / 2 : 0;
     const logicalCenter = getLabelCenter();
     const labelCenterLeft = logicalCenter.x + DRAWABLE_AREA.width / 2;
     const labelCenterTop = logicalCenter.y + DRAWABLE_AREA.height / 2;
+
+    if (!selected && toolbarVisible) {
+        setToolbarVisible(false);
+    }
+
+    const showToolbar = toolbarVisible && selected && selectState.edgeType == null
+        && editMode === EditModeType.SELECT
+        && dragState.status !== "on_dragging" && !isDragging;
+
+    const counterScale = 1 / displayScale;
+
+    const toolbar = (!showToolbar || !toolbarPortalRef.current) ? null : createPortal(
+        <div style={{
+            position: "absolute",
+            left,
+            top: top + (labelRef.current?.offsetHeight ?? 16),
+            transform: `scale(${counterScale})`,
+            transformOrigin: "top left",
+            marginTop: 4,
+            pointerEvents: "auto",
+            display: "flex",
+            alignItems: "center",
+            gap: 2,
+            backgroundColor: "#fff",
+            borderRadius: 4,
+            boxShadow: "0 1px 4px rgba(0,0,0,0.2)",
+            padding: "2px 4px"
+        }}
+            onClick={handlePreventMouseEvent}
+            onMouseDown={handlePreventMouseEvent}
+            onMouseUp={handlePreventMouseEvent}>
+            <ColorSelector
+                color={labelStyle.color ? ColorValue.fromHex(labelStyle.color) : undefined}
+                callback={handleSetColor} />
+            <Tooltip title="Decrease font size" placement="top">
+                <IconButton size="small" onClick={() => handleFontSizeChange(-1)}>
+                    <RemoveIcon fontSize="small" />
+                </IconButton>
+            </Tooltip>
+            <span style={{ fontSize: 12, minWidth: 20, textAlign: "center", lineHeight: "30px" }}>
+                {labelStyle.fontSize}
+            </span>
+            <Tooltip title="Increase font size" placement="top">
+                <IconButton size="small" onClick={() => handleFontSizeChange(1)}>
+                    <AddIcon fontSize="small" />
+                </IconButton>
+            </Tooltip>
+            <Tooltip title="Bold" placement="top">
+                <IconButton size="small"
+                    color={labelStyle.bold ? "primary" : "default"}
+                    onClick={handleToggleBold}>
+                    <FormatBoldIcon fontSize="small" />
+                </IconButton>
+            </Tooltip>
+            <Tooltip title="Italic" placement="top">
+                <IconButton size="small"
+                    color={labelStyle.italic ? "primary" : "default"}
+                    onClick={handleToggleItalic}>
+                    <FormatItalicIcon fontSize="small" />
+                </IconButton>
+            </Tooltip>
+            <Tooltip title="Strikethrough" placement="top">
+                <IconButton size="small"
+                    color={labelStyle.strikethrough ? "primary" : "default"}
+                    onClick={handleToggleStrikethrough}>
+                    <StrikethroughSIcon fontSize="small" />
+                </IconButton>
+            </Tooltip>
+        </div>,
+        toolbarPortalRef.current
+    );
 
     return (
         <>
@@ -217,18 +365,25 @@ const RelationLabelOverlay = ({ labelData, selected }: RelationLabelOverlayProps
                 position: "absolute",
                 left: `${left}px`,
                 top: `${top}px`,
-                fontSize: "13px",
-                color: selected || isDragging ? "#7B1FA2" : "rgba(60, 60, 60, 0.95)",
-                fontWeight: selected || isDragging ? 600 : 400,
-                textShadow: selected || isDragging ? "0 0 6px rgba(123, 31, 162, 0.4)" : "none",
+                fontSize: `${labelStyle.fontSize}px`,
+                fontStyle: labelStyle.italic ? "italic" : "normal",
+                textDecoration: labelStyle.strikethrough ? "line-through" : "none",
+                color: labelStyle.color ?? "rgba(60, 60, 60, 0.95)",
+                fontWeight: labelStyle.bold ? 700 : (selected || isDragging ? 600 : 400),
+                textShadow: selected || isDragging ? "0 0 8px rgba(123, 31, 162, 0.6)" : "none",
+                outline: selected || isDragging ? "1.5px solid rgba(123, 31, 162, 0.5)" : "none",
+                outlineOffset: "2px",
+                borderRadius: "2px",
                 cursor: "move",
                 userSelect: "none",
                 pointerEvents: "auto",
                 whiteSpace: "nowrap"
             }}
-                onMouseDown={handleMouseDown}>
+                onMouseDown={handleMouseDown}
+                onClick={handleClick}>
                 {relationName}
             </div>
+            {toolbar}
         </>
     );
 };

--- a/src/features/canvas/RelationLabelOverlay.tsx
+++ b/src/features/canvas/RelationLabelOverlay.tsx
@@ -1,0 +1,236 @@
+import React from "react";
+
+import { ErdDocumentsHolder, ErdDocumentsHolderContext } from "~/context/ErdDocumentsHolderContext";
+import DisplayScaleContext from "~/context/DisplayScaleContext";
+import CanvasPositionContext from "~/context/CanvasPositionContext";
+import { RelationLabelData } from "~/features/canvas/ErdRelationPathView";
+import { DRAWABLE_AREA } from "~/features/canvas/support";
+
+type Point = { x: number, y: number };
+
+type RelationLabelOverlayProps = {
+    labelData: RelationLabelData,
+    selected: boolean
+};
+
+const DEFAULT_SEGMENT = 0;
+const DEFAULT_FRACTION = 0.15;
+const DEFAULT_DY = -14;
+
+const pointOnSegment = (points: Point[], segment: number, fraction: number): Point => {
+    if (points.length < 2) return points[0] ?? { x: 0, y: 0 };
+    const i = Math.max(0, Math.min(segment, points.length - 2));
+    const f = Math.max(0, Math.min(1, fraction));
+    return {
+        x: points[i].x + f * (points[i + 1].x - points[i].x),
+        y: points[i].y + f * (points[i + 1].y - points[i].y)
+    };
+};
+
+const projectOntoPath = (points: Point[], target: Point): { segment: number, fraction: number, dx: number, dy: number } => {
+    if (points.length < 2) return { segment: 0, fraction: 0, dx: 0, dy: 0 };
+
+    let bestDist = Infinity;
+    let bestSegment = 0;
+    let bestFraction = 0;
+    let bestClosest: Point = points[0];
+
+    for (let i = 0; i < points.length - 1; i++) {
+        const sdx = points[i + 1].x - points[i].x;
+        const sdy = points[i + 1].y - points[i].y;
+        const len = Math.sqrt(sdx * sdx + sdy * sdy);
+        if (len === 0) { continue; }
+
+        const tx = target.x - points[i].x;
+        const ty = target.y - points[i].y;
+        const proj = Math.max(0, Math.min(1, (tx * sdx + ty * sdy) / (len * len)));
+
+        const cx = points[i].x + proj * sdx;
+        const cy = points[i].y + proj * sdy;
+        const dist = (target.x - cx) ** 2 + (target.y - cy) ** 2;
+
+        if (dist < bestDist) {
+            bestDist = dist;
+            bestSegment = i;
+            bestFraction = proj;
+            bestClosest = { x: cx, y: cy };
+        }
+    }
+
+    return {
+        segment: bestSegment,
+        fraction: bestFraction,
+        dx: target.x - bestClosest.x,
+        dy: target.y - bestClosest.y
+    };
+};
+
+const RelationLabelOverlay = ({ labelData, selected }: RelationLabelOverlayProps) => {
+    const documentsHolder: ErdDocumentsHolder = React.useContext(ErdDocumentsHolderContext);
+    const displayScale = React.useContext(DisplayScaleContext);
+    const positionResolver = React.useContext(CanvasPositionContext);
+    const labelRef = React.useRef<HTMLDivElement>(null);
+    const stableAnchorRef = React.useRef<Point | null>(null);
+    const prevPointCountRef = React.useRef(0);
+    const reanchorRef = React.useRef<{ segment: number, fraction: number, dx: number, dy: number } | null>(null);
+
+    const { relationView, pathPoints } = labelData;
+    const relationName = relationView.relationModel.relationName;
+    const persisted = relationView.lineViewModel.labelPosition;
+    const [dragPos, setDragPos] = React.useState<Point | null>(null);
+    const [isDragging, setIsDragging] = React.useState(false);
+
+    React.useEffect(() => {
+        if (reanchorRef.current) {
+            const data = reanchorRef.current;
+            reanchorRef.current = null;
+            documentsHolder.updateRelationLabelPosition(
+                relationView.relationId,
+                data,
+                `Re-anchor label: ${relationView.relationId}`
+            );
+        }
+    });
+
+    if (!relationName || pathPoints.length < 2) {
+        return null;
+    }
+
+    const hasPosition = persisted.segment >= 0;
+    let seg = hasPosition ? persisted.segment : DEFAULT_SEGMENT;
+    let frac = hasPosition ? persisted.fraction : DEFAULT_FRACTION;
+    const dx = hasPosition ? persisted.dx : 0;
+    const dy = hasPosition ? persisted.dy : DEFAULT_DY;
+
+    // When path topology changes (points added/removed via virtual edge drag),
+    // segment indices shift. Re-project the cached anchor world position to
+    // find the correct segment on the new path.
+    if (hasPosition
+        && stableAnchorRef.current !== null
+        && prevPointCountRef.current > 0
+        && prevPointCountRef.current !== pathPoints.length) {
+        const reproj = projectOntoPath(pathPoints, stableAnchorRef.current);
+        seg = reproj.segment;
+        frac = reproj.fraction;
+        reanchorRef.current = { segment: seg, fraction: frac, dx, dy };
+    }
+
+    const anchor = pointOnSegment(pathPoints, seg, frac);
+    stableAnchorRef.current = anchor;
+    prevPointCountRef.current = pathPoints.length;
+    const labelX = dragPos?.x ?? (anchor.x + dx);
+    const labelY = dragPos?.y ?? (anchor.y + dy);
+
+    const left = labelX + DRAWABLE_AREA.width / 2;
+    const top = labelY + DRAWABLE_AREA.height / 2;
+
+    const getLabelCenter = (): { x: number, y: number } => {
+        const el = labelRef.current;
+        if (el) return { x: labelX + el.offsetWidth / 2, y: labelY + el.offsetHeight / 2 };
+        return { x: labelX, y: labelY };
+    };
+
+    const showAnchor = isDragging || selected;
+    const anchorProjection = showAnchor
+        ? (() => {
+            const center = getLabelCenter();
+            const proj = projectOntoPath(pathPoints, center);
+            return pointOnSegment(pathPoints, proj.segment, proj.fraction);
+        })()
+        : null;
+
+    const handleMouseDown = (event: React.MouseEvent) => {
+        if (event.button !== 0) return;
+        event.stopPropagation();
+
+        const startPos = positionResolver.getLogicalPosition(event, displayScale);
+        const startLabel = { x: labelX, y: labelY };
+
+        setIsDragging(true);
+
+        const handleMouseMove = (moveEvent: MouseEvent) => {
+            const movePos = positionResolver.getLogicalPosition(moveEvent as unknown as React.MouseEvent, displayScale);
+            setDragPos({
+                x: startLabel.x + movePos.x - startPos.x,
+                y: startLabel.y + movePos.y - startPos.y
+            });
+        };
+
+        const handleMouseUp = (upEvent: MouseEvent) => {
+            window.removeEventListener("mousemove", handleMouseMove);
+            window.removeEventListener("mouseup", handleMouseUp);
+
+            const upPos = positionResolver.getLogicalPosition(upEvent as unknown as React.MouseEvent, displayScale);
+            const finalPos = {
+                x: startLabel.x + upPos.x - startPos.x,
+                y: startLabel.y + upPos.y - startPos.y
+            };
+
+            const projected = projectOntoPath(pathPoints, finalPos);
+
+            setIsDragging(false);
+            setDragPos(null);
+            documentsHolder.updateRelationLabelPosition(
+                relationView.relationId,
+                projected,
+                `Update relation label position: ${relationView.relationId}`
+            );
+        };
+
+        window.addEventListener("mousemove", handleMouseMove);
+        window.addEventListener("mouseup", handleMouseUp);
+    };
+
+    const projDotLeft = anchorProjection ? anchorProjection.x + DRAWABLE_AREA.width / 2 : 0;
+    const projDotTop = anchorProjection ? anchorProjection.y + DRAWABLE_AREA.height / 2 : 0;
+    const logicalCenter = getLabelCenter();
+    const labelCenterLeft = logicalCenter.x + DRAWABLE_AREA.width / 2;
+    const labelCenterTop = logicalCenter.y + DRAWABLE_AREA.height / 2;
+
+    return (
+        <>
+            {anchorProjection && (
+                <>
+                    <svg style={{
+                        position: "absolute", top: 0, left: 0,
+                        width: DRAWABLE_AREA.width, height: DRAWABLE_AREA.height,
+                        pointerEvents: "none", overflow: "visible"
+                    }}>
+                        <line
+                            x1={projDotLeft} y1={projDotTop}
+                            x2={labelCenterLeft} y2={labelCenterTop}
+                            stroke="rgba(123, 31, 162, 0.3)" strokeWidth={1}
+                            strokeDasharray="4 3" />
+                    </svg>
+                    <div style={{
+                        position: "absolute",
+                        left: `${projDotLeft - 4}px`,
+                        top: `${projDotTop - 4}px`,
+                        width: "8px", height: "8px",
+                        borderRadius: "50%",
+                        backgroundColor: "#7B1FA2",
+                        pointerEvents: "none"
+                    }} />
+                </>
+            )}
+            <div ref={labelRef} style={{
+                position: "absolute",
+                left: `${left}px`,
+                top: `${top}px`,
+                fontSize: "13px",
+                color: selected || isDragging ? "#7B1FA2" : "rgba(60, 60, 60, 0.95)",
+                fontWeight: selected || isDragging ? 600 : 400,
+                textShadow: selected || isDragging ? "0 0 6px rgba(123, 31, 162, 0.4)" : "none",
+                cursor: "move",
+                userSelect: "none",
+                pointerEvents: "auto",
+                whiteSpace: "nowrap"
+            }}
+                onMouseDown={handleMouseDown}>
+                {relationName}
+            </div>
+        </>
+    );
+};
+
+export default RelationLabelOverlay;

--- a/src/features/canvas/StickyMemoView.tsx
+++ b/src/features/canvas/StickyMemoView.tsx
@@ -56,6 +56,8 @@ const StickyMemoView = ({ memoViewModel, visible = true, onSettingAction, onDrag
     const [isTextEdit, setTextEdit] = React.useState<boolean>(false);
     const [mouseCursorStyle, setMouseCursorStyle] = React.useState<string>("pointer");
     const [resizingDirection, setResizingDirection] = React.useState<ResizingDirection>(ResizingDirection.NO_RESIZING);
+    const [toolbarVisible, setToolbarVisible] = React.useState(false);
+    const didDragRef = React.useRef(false);
 
     const selected = selectState.memoIds.has(memoViewModel.memoId);
 
@@ -89,6 +91,9 @@ const StickyMemoView = ({ memoViewModel, visible = true, onSettingAction, onDrag
         }
 
         event.stopPropagation();
+
+        setToolbarVisible(false);
+        didDragRef.current = false;
 
         const mousePosition = positionResolver.getLogicalPosition(event, displayScale);
         onDragAction({ type: "start_dragging", start: mousePosition });
@@ -132,6 +137,14 @@ const StickyMemoView = ({ memoViewModel, visible = true, onSettingAction, onDrag
         }
 
         if (!resizingDirection.isResizing()) {
+            const delta = dragState.delta();
+            const didDrag = delta.x !== 0 || delta.y !== 0;
+
+            if (didDrag) {
+                didDragRef.current = true;
+                return;
+            }
+
             if ((selectState.status === "on_selecting")
                 && (selectState.memoIds.has(memoViewModel.memoId))) {
                 dispatchSelectAction({ type: "completed" });
@@ -175,6 +188,10 @@ const StickyMemoView = ({ memoViewModel, visible = true, onSettingAction, onDrag
             return;
         }
 
+        if (!didDragRef.current) {
+            setToolbarVisible(true);
+        }
+        didDragRef.current = false;
         event.stopPropagation();
     };
 
@@ -197,6 +214,10 @@ const StickyMemoView = ({ memoViewModel, visible = true, onSettingAction, onDrag
         })}`;
         documentsHolder.updateMemo(nextMemo, loggingMessage);
     };
+
+    if (!selected && toolbarVisible) {
+        setToolbarVisible(false);
+    }
 
     const moving = (
         selected && (dragState.status === "on_dragging") && !resizingDirection.isResizing()
@@ -301,7 +322,7 @@ const StickyMemoView = ({ memoViewModel, visible = true, onSettingAction, onDrag
                 className={stickyClassName} onBlur={handleFocusOut}>
                 {initTextAreaElement()}
             </Box>
-            {selected && (!isTextEdit) && (dragState.status !== "on_dragging")
+            {toolbarVisible && selected && (!isTextEdit) && (dragState.status !== "on_dragging")
                 && (selectState.tableIds.size + selectState.memoIds.size === 1)
                 && <StickyControlPane memoViewModel={memoViewModel} onSettingAction={onSettingAction} />}
         </Box>

--- a/src/models/ErdSettingModel.ts
+++ b/src/models/ErdSettingModel.ts
@@ -8,13 +8,15 @@ import { toObjects } from "~/models/util";
 type ErdSettingModelOptions = {
     displayStyle?: DisplayStyle,
     exportDdlSetting: ExportDdlSettingModel,
-    perspectiveModelStorage: PerspectiveModelStorage
+    perspectiveModelStorage: PerspectiveModelStorage,
+    showRelationNames?: boolean
 };
 
 type UpdatingArgs = {
     displayStyle?: DisplayStyle | null,
     exportDdlSetting?: ExportDdlSettingModel | null,
-    perspectiveModels?: PerspectiveModel[] | null
+    perspectiveModels?: PerspectiveModel[] | null,
+    showRelationNames?: boolean | null
 };
 
 export default class ErdSettingModel {
@@ -22,13 +24,15 @@ export default class ErdSettingModel {
     public readonly displayStyle: DisplayStyle;
     public readonly exportDdlSetting: ExportDdlSettingModel;
     private readonly perspectiveModelStorage: PerspectiveModelStorage;
+    public readonly showRelationNames: boolean;
 
     private constructor({
-        displayStyle = DisplayStyle.BOTH, exportDdlSetting, perspectiveModelStorage
+        displayStyle = DisplayStyle.BOTH, exportDdlSetting, perspectiveModelStorage, showRelationNames = false
     }: ErdSettingModelOptions) {
         this.displayStyle = displayStyle;
         this.exportDdlSetting = exportDdlSetting;
         this.perspectiveModelStorage = perspectiveModelStorage;
+        this.showRelationNames = showRelationNames;
     }
 
     public static create(documentName: string): ErdSettingModel {
@@ -47,10 +51,10 @@ export default class ErdSettingModel {
     }
 
     public update({
-        displayStyle = null, exportDdlSetting = null, perspectiveModels = null
+        displayStyle = null, exportDdlSetting = null, perspectiveModels = null, showRelationNames = null
     }: UpdatingArgs): ErdSettingModel {
 
-        if ((displayStyle == null) && (exportDdlSetting == null) && (perspectiveModels == null)) {
+        if ((displayStyle == null) && (exportDdlSetting == null) && (perspectiveModels == null) && (showRelationNames == null)) {
             return this;
         }
 
@@ -58,7 +62,8 @@ export default class ErdSettingModel {
             displayStyle: ((displayStyle != null) ? displayStyle : this.displayStyle),
             exportDdlSetting: ((exportDdlSetting != null) ? exportDdlSetting : this.exportDdlSetting),
             perspectiveModelStorage: ((perspectiveModels != null)
-                ? new PerspectiveModelStorage(perspectiveModels) : this.perspectiveModelStorage)
+                ? new PerspectiveModelStorage(perspectiveModels) : this.perspectiveModelStorage),
+            showRelationNames: ((showRelationNames != null) ? showRelationNames : this.showRelationNames)
         });
     }
 
@@ -81,7 +86,8 @@ export default class ErdSettingModel {
         return {
             displayStyle: this.displayStyle.toJSON(),
             exportDdlSetting: this.exportDdlSetting.toJSON(),
-            ...((perspectiveModels.length > 0) && { perspectiveModels: perspectiveModels })
+            ...((perspectiveModels.length > 0) && { perspectiveModels: perspectiveModels }),
+            ...(this.showRelationNames && { showRelationNames: true })
         };
     }
 
@@ -96,10 +102,13 @@ export default class ErdSettingModel {
         const perspectiveModels = ("perspectiveModels" in obj)
             ? toObjects(obj.perspectiveModels, "perspectiveModels", value => PerspectiveModel.toObject(value)) : [];
 
+        const showRelationNames = ("showRelationNames" in obj) ? obj.showRelationNames as boolean : false;
+
         return new ErdSettingModel({
             displayStyle,
             exportDdlSetting,
-            perspectiveModelStorage: new PerspectiveModelStorage(perspectiveModels)
+            perspectiveModelStorage: new PerspectiveModelStorage(perspectiveModels),
+            showRelationNames
         });
     }
 
@@ -111,6 +120,9 @@ export default class ErdSettingModel {
             return false;
         }
         if (!this.perspectiveModelStorage.equals(other.perspectiveModelStorage)) {
+            return false;
+        }
+        if (this.showRelationNames !== other.showRelationNames) {
             return false;
         }
 

--- a/src/models/LineViewModel.ts
+++ b/src/models/LineViewModel.ts
@@ -14,11 +14,14 @@ type MarkerDraggingType = {
     point: Point
 };
 
+export type LabelPosition = { segment: number, fraction: number, dx: number, dy: number };
+
 type LineViewModelOptions = {
     strokeWidth?: number,
     edges?: Point[],
     orthogonalLines?: OrthogonalDirection[],
-    color?: ColorValue
+    color?: ColorValue,
+    labelPosition?: LabelPosition
 };
 
 export default class LineViewModel {
@@ -27,12 +30,14 @@ export default class LineViewModel {
     public readonly edges: Point[];
     public readonly orthogonalLines: OrthogonalDirection[];
     public readonly color: ColorValue;
+    public readonly labelPosition: LabelPosition;
 
-    constructor({ strokeWidth = 1, edges = [], orthogonalLines = [], color = ColorValue.BLACK }: LineViewModelOptions) {
+    constructor({ strokeWidth = 1, edges = [], orthogonalLines = [], color = ColorValue.BLACK, labelPosition = { segment: -1, fraction: 0, dx: 0, dy: 0 } }: LineViewModelOptions) {
         this.strokeWidth = (strokeWidth > 0) ? strokeWidth : 1;
         this.edges = [...edges] as const;
         this.orthogonalLines = [...orthogonalLines] as const;
         this.color = color;
+        this.labelPosition = labelPosition;
     }
 
     public get lineType(): ("orthogonal" | "straight") {
@@ -77,6 +82,17 @@ export default class LineViewModel {
         return new LineViewModel({ ...this, color: nextColor });
     }
 
+    public updateLabelPosition(next: LabelPosition): LineViewModel {
+        if (this.labelPosition.segment === next.segment
+            && this.labelPosition.fraction === next.fraction
+            && this.labelPosition.dx === next.dx
+            && this.labelPosition.dy === next.dy) {
+            return this;
+        }
+
+        return new LineViewModel({ ...this, labelPosition: next });
+    }
+
     public deleteEdge(index: number): LineViewModel {
         if ((index < 0) || (index >= this.edges.length)) {
             return this;
@@ -116,20 +132,38 @@ export default class LineViewModel {
         if (this.orthogonalLines.length !== other.orthogonalLines.length) {
             return false;
         }
-        return this.orthogonalLines.every((line, index) => {
+        const isMatchOrthogonal = this.orthogonalLines.every((line, index) => {
             const otherLine = other.orthogonalLines[index];
             return (line.direction === otherLine.direction)
                 && (line.position === otherLine.position);
         });
+        if (!isMatchOrthogonal) {
+            return false;
+        }
+
+        if (this.labelPosition.segment !== other.labelPosition.segment
+            || this.labelPosition.fraction !== other.labelPosition.fraction
+            || this.labelPosition.dx !== other.labelPosition.dx
+            || this.labelPosition.dy !== other.labelPosition.dy) {
+            return false;
+        }
+
+        return true;
     }
 
     public toJSON(): Record<string, unknown> {
-        return {
+        const json: Record<string, unknown> = {
             strokeWidth: this.strokeWidth,
             edges: this.edges,
             orthogonalLines: this.orthogonalLines,
             color: this.color.toJSON()
         };
+
+        if (this.labelPosition.segment >= 0) {
+            json.labelPosition = this.labelPosition;
+        }
+
+        return json;
     }
 
     public static toObject(obj: object): LineViewModel {
@@ -140,12 +174,16 @@ export default class LineViewModel {
         const edges = ("edges" in obj) ? obj.edges as Point[] : [];
         const orthogonalLines = ("orthogonalLines" in obj) ? obj.orthogonalLines as OrthogonalDirection[] : [];
         const color = ("color" in obj) ? ColorValue.toObject(obj.color as object) : ColorValue.BLACK;
+        const labelPosition = ("labelPosition" in obj)
+            ? obj.labelPosition as LabelPosition
+            : { segment: -1, fraction: 0, dx: 0, dy: 0 };
 
         return new LineViewModel({
             strokeWidth: obj.strokeWidth as number,
             edges: edges,
             orthogonalLines: orthogonalLines,
-            color: color
+            color: color,
+            labelPosition: labelPosition
         });
     }
 }

--- a/src/models/LineViewModel.ts
+++ b/src/models/LineViewModel.ts
@@ -15,13 +15,15 @@ type MarkerDraggingType = {
 };
 
 export type LabelPosition = { segment: number, fraction: number, dx: number, dy: number };
+export type LabelStyle = { bold: boolean, italic: boolean, strikethrough: boolean, fontSize: number, color?: string };
 
 type LineViewModelOptions = {
     strokeWidth?: number,
     edges?: Point[],
     orthogonalLines?: OrthogonalDirection[],
     color?: ColorValue,
-    labelPosition?: LabelPosition
+    labelPosition?: LabelPosition,
+    labelStyle?: LabelStyle
 };
 
 export default class LineViewModel {
@@ -31,13 +33,15 @@ export default class LineViewModel {
     public readonly orthogonalLines: OrthogonalDirection[];
     public readonly color: ColorValue;
     public readonly labelPosition: LabelPosition;
+    public readonly labelStyle: LabelStyle;
 
-    constructor({ strokeWidth = 1, edges = [], orthogonalLines = [], color = ColorValue.BLACK, labelPosition = { segment: -1, fraction: 0, dx: 0, dy: 0 } }: LineViewModelOptions) {
+    constructor({ strokeWidth = 1, edges = [], orthogonalLines = [], color = ColorValue.BLACK, labelPosition = { segment: -1, fraction: 0, dx: 0, dy: 0 }, labelStyle = { bold: false, italic: false, strikethrough: false, fontSize: 13 } }: LineViewModelOptions) {
         this.strokeWidth = (strokeWidth > 0) ? strokeWidth : 1;
         this.edges = [...edges] as const;
         this.orthogonalLines = [...orthogonalLines] as const;
         this.color = color;
         this.labelPosition = labelPosition;
+        this.labelStyle = labelStyle;
     }
 
     public get lineType(): ("orthogonal" | "straight") {
@@ -91,6 +95,18 @@ export default class LineViewModel {
         }
 
         return new LineViewModel({ ...this, labelPosition: next });
+    }
+
+    public updateLabelStyle(next: LabelStyle): LineViewModel {
+        if (this.labelStyle.bold === next.bold
+            && this.labelStyle.italic === next.italic
+            && this.labelStyle.strikethrough === next.strikethrough
+            && this.labelStyle.fontSize === next.fontSize
+            && this.labelStyle.color === next.color) {
+            return this;
+        }
+
+        return new LineViewModel({ ...this, labelStyle: next });
     }
 
     public deleteEdge(index: number): LineViewModel {
@@ -148,6 +164,14 @@ export default class LineViewModel {
             return false;
         }
 
+        if (this.labelStyle.bold !== other.labelStyle.bold
+            || this.labelStyle.italic !== other.labelStyle.italic
+            || this.labelStyle.strikethrough !== other.labelStyle.strikethrough
+            || this.labelStyle.fontSize !== other.labelStyle.fontSize
+            || this.labelStyle.color !== other.labelStyle.color) {
+            return false;
+        }
+
         return true;
     }
 
@@ -161,6 +185,11 @@ export default class LineViewModel {
 
         if (this.labelPosition.segment >= 0) {
             json.labelPosition = this.labelPosition;
+        }
+
+        if (this.labelStyle.bold || this.labelStyle.italic || this.labelStyle.strikethrough
+            || this.labelStyle.fontSize !== 13 || this.labelStyle.color) {
+            json.labelStyle = this.labelStyle;
         }
 
         return json;
@@ -177,13 +206,17 @@ export default class LineViewModel {
         const labelPosition = ("labelPosition" in obj)
             ? obj.labelPosition as LabelPosition
             : { segment: -1, fraction: 0, dx: 0, dy: 0 };
+        const labelStyle = ("labelStyle" in obj)
+            ? obj.labelStyle as LabelStyle
+            : { bold: false, italic: false, strikethrough: false, fontSize: 13 };
 
         return new LineViewModel({
             strokeWidth: obj.strokeWidth as number,
             edges: edges,
             orthogonalLines: orthogonalLines,
             color: color,
-            labelPosition: labelPosition
+            labelPosition: labelPosition,
+            labelStyle: labelStyle
         });
     }
 }


### PR DESCRIPTION
## Summary

- Add a formatting toolbar for relation labels: bold, italic, strikethrough, font size, color
- Toolbar appears below the label on explicit click, hidden during drag
- Apply click-to-show pattern to all toolbars (table, memo, connection, label) — prevents toolbars from reappearing after drag-and-drop

Closes #163

**Stacked on #162, #159, and #160** — merge those first, then this PR’s diff will be clean.

## Changes

| File | Change |
|------|--------|
| src/models/LineViewModel.ts | LabelStyle type, field, update, equals, serialize |
| src/context/ErdDocumentsHolderContext.ts | updateRelationLabelStyle method |
| src/context/SelectEntityContext.ts | SelectRelationAction for label click-to-select |
| src/features/canvas/RelationLabelOverlay.tsx | Apply styles, click handler, portal toolbar |
| src/features/canvas/ErdTableView.tsx | Click-to-show toolbar pattern |
| src/features/canvas/StickyMemoView.tsx | Click-to-show toolbar pattern |
| src/features/canvas/ErdRelationPathView.tsx | Click-to-show toolbar pattern |
| src/features/canvas/ErdCanvas.tsx | Remove scale transform from toolbar portal |

## Test plan

- [ ] Click a relation label → toolbar appears below
- [ ] Toggle bold/italic/strikethrough → label text updates, persists after reload
- [ ] Change font size → label resizes, persists
- [ ] Change color → label color updates, persists
- [ ] Drag label → toolbar hidden during drag, does NOT reappear after drop
- [ ] Click label again after drag → toolbar reappears
- [ ] Drag a table/memo → their toolbar does NOT reappear after drop
- [ ] Click table/memo after drag → toolbar reappears
- [ ] Undo/redo → style changes revert/reapply correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)