### PR TITLE
fix: filter relation labels by active perspective

### DIFF
--- a/src/features/canvas/ErdCanvas.tsx
+++ b/src/features/canvas/ErdCanvas.tsx
@@ -324,7 +324,16 @@ const ErdCanvas = () => {
         setSvgPaths(svgPaths);
 
         if (relationRef.current != null) {
-            setRelationLabels(relationRef.current.labelData());
+            const allLabels = relationRef.current.labelData();
+            const filteredLabels = (currentPerspective == null)
+                ? allLabels
+                : allLabels.filter(label => {
+                    const rm = label.relationView.relationModel;
+                    return (localSetting.visibleLineStyle === "both-bounded")
+                        ? currentPerspective.containsModel(rm.parentTableModelId) && currentPerspective.containsModel(rm.childTableModelId)
+                        : currentPerspective.containsModel(rm.parentTableModelId) || currentPerspective.containsModel(rm.childTableModelId);
+                });
+            setRelationLabels(filteredLabels);
         }
     }, [selectState, dragState, rectangleArea, localSetting.visibleLineStyle, localSetting.showRelationNames, erdDocument, currentPerspective]);
 


### PR DESCRIPTION
## Summary

- Relation labels were rendered for all relations regardless of the active perspective, even though SVG paths were correctly filtered
- Apply the same `currentPerspective.containsModel()` + `visibleLineStyle` logic to `labelData()` filtering

**Root cause:** `setRelationLabels(relationRef.current.labelData())` at `ErdCanvas.tsx:327` passed unfiltered labels, while `setSvgPaths` (line 323) used `targetElements` filtered by perspective.

Introduced in #160.

## Test plan

- Switch perspectives — only labels for visible relations should appear
- Verify `both-bounded` vs `some` line style setting is respected for labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)