### PR TITLE
feat: export ERD as interactive HTML

### DIFF
--- a/src/features/canvas/ControlPanel.tsx
+++ b/src/features/canvas/ControlPanel.tsx
@@ -285,6 +285,13 @@ const SubMenuPanel = ({ erdExportable }: SubMenuButtonProps) => {
         handleCloseMenu();
     };
 
+    const handleSaveAsHtml = () => {
+        dispatchSelectAction(RELEASE_ACTION);
+
+        downloadHtml(erdDocument);
+        handleCloseMenu();
+    };
+
     const handleBatchExportPerspectives = () => {
         dispatchSelectAction(RELEASE_ACTION);
 
@@ -331,6 +338,7 @@ const SubMenuPanel = ({ erdExportable }: SubMenuButtonProps) => {
                 slotProps={{ paper: { 'aria-labelledby': 'basic-button', } }}>
                 <MenuItem onClick={() => setSelectedMenu("export_ddl")}>Export DDL</MenuItem>
                 <MenuItem onClick={handleSaveAsImage}>Save as image</MenuItem>
+                <MenuItem onClick={handleSaveAsHtml}>Save as interactive HTML</MenuItem>
                 <MenuItem onClick={handleBatchExportPerspectives}
                     disabled={erdDocument.erdSettingModel.getPerspectiveModels().length === 0}>
                     Export all perspectives as images
@@ -361,6 +369,259 @@ const downloadImage = (erdDocument: ErdDocument) => {
 
         download(fileName, contents.base64Value);
     });
+};
+
+const downloadHtml = (erdDocument: ErdDocument) => {
+    const erdCanvas = document.getElementById("erd-canvas");
+    if (erdCanvas == null) return;
+
+    const orgScale = erdCanvas.style.transform;
+    erdCanvas.style.transform = "scale(1)";
+
+    const { leftEdge, topEdge, rightEdge, bottomEdge } = doCalculateImageArea(erdCanvas);
+    const pad = 100;
+    const cropX = leftEdge - pad;
+    const cropY = topEdge - pad;
+    const contentW = rightEdge - leftEdge + pad * 2;
+    const contentH = bottomEdge - topEdge + pad * 2;
+
+    const clone = erdCanvas.cloneNode(true) as HTMLElement;
+
+    clone.removeAttribute("id");
+    clone.style.transform = "none";
+    clone.style.position = "absolute";
+    clone.style.left = "0";
+    clone.style.top = "0";
+
+    clone.querySelectorAll("[id='toolbar-portal'], [id='relation-toolbar-container']").forEach(el => el.remove());
+    clone.querySelectorAll(".MuiPopover-root, .MuiPopper-root").forEach(el => el.remove());
+
+    // Reset perspective-hidden elements and propagate model IDs to wrappers for JS filtering.
+    // The editor sets opacity/pointerEvents on the PARENT wrapper, not the .erdTableView/.erdMemoView itself.
+    // Also copy the id to a data-model-id on the wrapper so JS can filter by wrapper directly.
+    clone.querySelectorAll('.erdTableView, .erdMemoView').forEach(el => {
+        const wrapper = (el as HTMLElement).parentElement;
+        if (wrapper) {
+            wrapper.style.opacity = '';
+            wrapper.style.pointerEvents = '';
+            wrapper.setAttribute('data-model-id', (el as HTMLElement).id);
+        }
+    });
+    // Memo wrappers have z-index:-100 which puts them behind the white canvas background.
+    // Raise them to z-index:0 so they're visible but still behind tables.
+    clone.querySelectorAll('.erdMemoView').forEach(el => {
+        const wrapper = (el as HTMLElement).parentElement;
+        if (wrapper) {
+            wrapper.style.zIndex = '0';
+        }
+    });
+
+    // SVG <g> groups and label divs already have data-parent/data-child from React render.
+
+    const sheets = Array.from(document.styleSheets);
+    let inlinedCss = "";
+    for (const sheet of sheets) {
+        try {
+            const rules = sheet.cssRules || sheet.rules;
+            for (const rule of Array.from(rules)) {
+                inlinedCss += rule.cssText + "\n";
+            }
+        } catch (_) { /* cross-origin sheets */ }
+    }
+
+    const perspectives = erdDocument.erdSettingModel.getPerspectiveModels();
+    const perspJson = JSON.stringify(perspectives.map(p => ({
+        id: p.perspectiveId,
+        name: p.perspectiveName,
+        ids: p.getContainIds()
+    })));
+
+    const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>${erdDocument.documentName}</title>
+<meta name="export-id" content="${crypto.randomUUID()}">
+<style>
+${inlinedCss}
+* { margin: 0; padding: 0; box-sizing: border-box; }
+html, body { width: 100%; height: 100%; overflow: hidden; background: #f5f5f5; }
+#toolbar {
+  position: fixed !important; top: 0 !important; left: 0 !important; right: 0 !important; z-index: 10000 !important;
+  display: flex !important; align-items: center !important; gap: 12px !important;
+  padding: 8px 16px !important; background: #fff !important; border-bottom: 1px solid #ddd !important;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1) !important; font-size: 13px !important;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif !important;
+  color: #333 !important; visibility: visible !important; opacity: 1 !important;
+}
+#toolbar * { visibility: visible !important; opacity: 1 !important; color: inherit !important; }
+#toolbar label { font-weight: 600 !important; color: #444 !important; }
+#toolbar select { padding: 4px 8px !important; border-radius: 4px !important; border: 1px solid #ccc !important; font-size: 13px !important; max-width: 340px !important; background: #fff !important; color: #333 !important; }
+#toolbar .zoom-controls { display: flex !important; align-items: center !important; gap: 4px !important; margin-left: auto !important; }
+#toolbar button { padding: 4px 10px !important; border: 1px solid #ccc !important; border-radius: 4px !important; background: #fff !important; cursor: pointer !important; font-size: 13px !important; color: #333 !important; }
+#toolbar button:hover { background: #f0f0f0 !important; }
+#zoom-display { min-width: 44px !important; text-align: center !important; color: #333 !important; }
+#toolbar .title { font-weight: 700 !important; color: #333 !important; font-size: 14px !important; }
+#search-box { padding: 4px 8px !important; border-radius: 4px !important; border: 1px solid #ccc !important; font-size: 13px !important; width: 180px !important; background: #fff !important; color: #333 !important; }
+#viewport { position: absolute; top: 42px; left: 0; right: 0; bottom: 0; overflow: hidden; cursor: grab; }
+#viewport.grabbing { cursor: grabbing; }
+#canvas-wrapper { position: absolute; transform-origin: 0 0; }
+.search-highlight { outline: 3px solid #ff6b00 !important; outline-offset: 2px; z-index: 10000 !important; }
+</style>
+</head>
+<body>
+<div id="toolbar">
+  <span class="title">${erdDocument.documentName}</span>
+  <label for="perspective-select">Perspective:</label>
+  <select id="perspective-select">
+    <option value="all" selected>All</option>
+  </select>
+  <input id="search-box" type="text" placeholder="Search tables...">
+  <div class="zoom-controls">
+    <button id="zoom-out">\u2212</button>
+    <span id="zoom-display">100%</span>
+    <button id="zoom-in">+</button>
+    <button id="zoom-fit">Fit</button>
+  </div>
+</div>
+<div id="viewport">
+  <div id="canvas-wrapper">
+    ${clone.outerHTML}
+  </div>
+</div>
+<script>
+(function() {
+  const viewport = document.getElementById('viewport');
+  const wrapper = document.getElementById('canvas-wrapper');
+  const perspSelect = document.getElementById('perspective-select');
+  const searchBox = document.getElementById('search-box');
+  const zoomDisplay = document.getElementById('zoom-display');
+  const cropX = ${cropX}, cropY = ${cropY};
+  const contentW = ${contentW}, contentH = ${contentH};
+  const PERSPECTIVES = ${perspJson};
+
+  PERSPECTIVES.forEach(p => {
+    const opt = document.createElement('option');
+    opt.value = p.id;
+    opt.textContent = p.name;
+    perspSelect.appendChild(opt);
+  });
+
+  const idSet = new Map();
+  PERSPECTIVES.forEach(p => idSet.set(p.id, new Set(p.ids)));
+
+  let scale = 1, panX = 0, panY = 0;
+  let isPanning = false, startX = 0, startY = 0, startPanX = 0, startPanY = 0;
+
+  function applyTransform() {
+    wrapper.style.transform = 'translate(' + panX + 'px,' + panY + 'px) scale(' + scale + ')';
+    zoomDisplay.textContent = Math.round(scale * 100) + '%';
+  }
+
+  function fitAll() {
+    const vw = viewport.clientWidth, vh = viewport.clientHeight;
+    scale = Math.min(vw / contentW, vh / contentH, 2) * 0.95;
+    panX = (vw - contentW * scale) / 2 - cropX * scale;
+    panY = (vh - contentH * scale) / 2 - cropY * scale;
+    applyTransform();
+  }
+
+  fitAll();
+
+  viewport.addEventListener('mousedown', e => {
+    if (e.button !== 0) return;
+    isPanning = true; startX = e.clientX; startY = e.clientY;
+    startPanX = panX; startPanY = panY;
+    viewport.classList.add('grabbing');
+  });
+  window.addEventListener('mousemove', e => {
+    if (!isPanning) return;
+    panX = startPanX + e.clientX - startX;
+    panY = startPanY + e.clientY - startY;
+    applyTransform();
+  });
+  window.addEventListener('mouseup', () => { isPanning = false; viewport.classList.remove('grabbing'); });
+
+  viewport.addEventListener('wheel', e => {
+    e.preventDefault();
+    const rect = viewport.getBoundingClientRect();
+    const mx = e.clientX - rect.left, my = e.clientY - rect.top;
+    const wx = (mx - panX) / scale, wy = (my - panY) / scale;
+    const d = e.deltaY > 0 ? 0.9 : 1.1;
+    scale = Math.max(0.05, Math.min(5, scale * d));
+    panX = mx - wx * scale; panY = my - wy * scale;
+    applyTransform();
+  }, { passive: false });
+
+  document.getElementById('zoom-in').addEventListener('click', () => {
+    const rect = viewport.getBoundingClientRect();
+    const cx = rect.width/2, cy = rect.height/2;
+    const wx = (cx-panX)/scale, wy = (cy-panY)/scale;
+    scale = Math.min(5, scale*1.25); panX = cx-wx*scale; panY = cy-wy*scale; applyTransform();
+  });
+  document.getElementById('zoom-out').addEventListener('click', () => {
+    const rect = viewport.getBoundingClientRect();
+    const cx = rect.width/2, cy = rect.height/2;
+    const wx = (cx-panX)/scale, wy = (cy-panY)/scale;
+    scale = Math.max(0.05, scale/1.25); panX = cx-wx*scale; panY = cy-wy*scale; applyTransform();
+  });
+  document.getElementById('zoom-fit').addEventListener('click', fitAll);
+
+  function applyPerspective(pid) {
+    const modelWrappers = wrapper.querySelectorAll('[data-model-id]');
+    const relElements = wrapper.querySelectorAll('[data-parent]');
+    const ids = pid === 'all' ? null : idSet.get(pid);
+    modelWrappers.forEach(el => {
+      const mid = el.getAttribute('data-model-id');
+      const show = !ids || ids.has(mid);
+      el.style.opacity = show ? '' : '0';
+      el.style.pointerEvents = show ? '' : 'none';
+    });
+    relElements.forEach(el => {
+      const p = el.getAttribute('data-parent');
+      const c = el.getAttribute('data-child');
+      const show = !ids || (ids.has(p) && ids.has(c));
+      el.style.display = show ? '' : 'none';
+      el.setAttribute('visibility', show ? 'visible' : 'hidden');
+    });
+  }
+
+  perspSelect.addEventListener('change', () => applyPerspective(perspSelect.value));
+
+  searchBox.addEventListener('input', () => {
+    const q = searchBox.value.toLowerCase().trim();
+    wrapper.querySelectorAll('.search-highlight').forEach(el => el.classList.remove('search-highlight'));
+    if (!q) return;
+    wrapper.querySelectorAll('.erdTableView').forEach(el => {
+      const header = el.querySelector('[class*="header"], div:first-child');
+      if (header && header.textContent.toLowerCase().includes(q)) el.classList.add('search-highlight');
+    });
+  });
+
+  document.addEventListener('keydown', e => {
+    if (e.key === '0' && (e.metaKey || e.ctrlKey)) { e.preventDefault(); fitAll(); }
+    if (e.key === '=' && (e.metaKey || e.ctrlKey)) { e.preventDefault(); document.getElementById('zoom-in').click(); }
+    if (e.key === '-' && (e.metaKey || e.ctrlKey)) { e.preventDefault(); document.getElementById('zoom-out').click(); }
+    if (e.key === '/' && !e.metaKey && !e.ctrlKey) { e.preventDefault(); searchBox.focus(); }
+    if (e.key === 'Escape') { searchBox.blur(); searchBox.value = ''; searchBox.dispatchEvent(new Event('input')); }
+    if ((e.key === 'ArrowDown' || e.key === 'ArrowUp') && document.activeElement !== searchBox) {
+      e.preventDefault();
+      const opts = perspSelect.options;
+      const dir = e.key === 'ArrowDown' ? 1 : -1;
+      const next = perspSelect.selectedIndex + dir;
+      if (next >= 0 && next < opts.length) { perspSelect.selectedIndex = next; perspSelect.dispatchEvent(new Event('change')); }
+    }
+  });
+})();
+</script>
+</body>
+</html>`;
+
+    erdCanvas.style.transform = orgScale;
+
+    const blob = new Blob([html], { type: "text/html" });
+    const fileName = `${erdDocument.documentName}.html`;
+    download(fileName, blob);
 };
 
 const downloadSpecification = (

--- a/src/features/canvas/ControlPanel.tsx
+++ b/src/features/canvas/ControlPanel.tsx
@@ -29,7 +29,7 @@ import { LocalSettingContext } from "~/context/LocalSettingContext";
 import { ERD_MEMO_VIEW_CLASS_NAME } from "~/features/canvas/StickyMemoView";
 import ExportSpecificationContext, { ImageContent } from "~/context/ExportSpecificationContext";
 import DescriptionTooltip from "~/features/canvas/DescriptionTooltip";
-import { getScroll } from "~/features/canvas/support";
+import { DRAWABLE_AREA, getScroll } from "~/features/canvas/support";
 
 type ControlPanelProps = {
     erdExportable: boolean
@@ -436,6 +436,28 @@ const downloadHtml = (erdDocument: ErdDocument) => {
         ids: p.getContainIds()
     })));
 
+    const { frontMemos: htmlFrontMemos, backMemos: htmlBackMemos } = erdDocument.getMemoViewModels();
+    const htmlAllMemos = [...htmlBackMemos, ...htmlFrontMemos];
+    const htmlTableViewModels = erdDocument.getTableViewModels();
+    const htmlMemoTableMap: Record<string, string[]> = {};
+    for (const memo of htmlAllMemos) {
+        const r = memo.rectangleViewModel;
+        const mx = r.positionX + DRAWABLE_AREA.width / 2;
+        const my = r.positionY + DRAWABLE_AREA.height / 2;
+        const contained = htmlTableViewModels
+            .filter(t => {
+                const tx = t.corner.left + DRAWABLE_AREA.width / 2;
+                const ty = t.corner.top + DRAWABLE_AREA.height / 2;
+                const el = document.getElementById(t.tableId);
+                const tw = el ? el.offsetWidth : 220;
+                const th = el ? el.offsetHeight : 100;
+                return tx >= mx && ty >= my && tx + tw <= mx + r.width && ty + th <= my + r.height;
+            })
+            .map(t => t.tableId);
+        if (contained.length > 0) htmlMemoTableMap[memo.memoId] = contained;
+    }
+    const htmlMemoTableJson = JSON.stringify(htmlMemoTableMap);
+
     const html = `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -499,6 +521,7 @@ html, body { width: 100%; height: 100%; overflow: hidden; background: #f5f5f5; }
   const cropX = ${cropX}, cropY = ${cropY};
   const contentW = ${contentW}, contentH = ${contentH};
   const PERSPECTIVES = ${perspJson};
+  const MEMO_TABLES = ${htmlMemoTableJson};
 
   PERSPECTIVES.forEach(p => {
     const opt = document.createElement('option');
@@ -518,11 +541,28 @@ html, body { width: 100%; height: 100%; overflow: hidden; background: #f5f5f5; }
     zoomDisplay.textContent = Math.round(scale * 100) + '%';
   }
 
+  function visibleBounds() {
+    const models = wrapper.querySelectorAll('[data-model-id]');
+    let mnX = Infinity, mnY = Infinity, mxX = -Infinity, mxY = -Infinity;
+    models.forEach(el => {
+      if (el.style.opacity === '0') return;
+      const r = el.getBoundingClientRect();
+      const wx = (el.offsetLeft || r.left);
+      const wy = (el.offsetTop || r.top);
+      mnX = Math.min(mnX, wx); mnY = Math.min(mnY, wy);
+      mxX = Math.max(mxX, wx + r.width / scale); mxY = Math.max(mxY, wy + r.height / scale);
+    });
+    if (mnX === Infinity) return { cx: cropX, cy: cropY, cw: contentW, ch: contentH };
+    const pad = 100;
+    return { cx: mnX - pad, cy: mnY - pad, cw: mxX - mnX + pad * 2, ch: mxY - mnY + pad * 2 };
+  }
+
   function fitAll() {
     const vw = viewport.clientWidth, vh = viewport.clientHeight;
-    scale = Math.min(vw / contentW, vh / contentH, 2) * 0.95;
-    panX = (vw - contentW * scale) / 2 - cropX * scale;
-    panY = (vh - contentH * scale) / 2 - cropY * scale;
+    const { cx, cy, cw, ch } = visibleBounds();
+    scale = Math.min(vw / cw, vh / ch, 2) * 0.95;
+    panX = (vw - cw * scale) / 2 - cx * scale;
+    panY = (vh - ch * scale) / 2 - cy * scale;
     applyTransform();
   }
 
@@ -573,7 +613,12 @@ html, body { width: 100%; height: 100%; overflow: hidden; background: #f5f5f5; }
     const ids = pid === 'all' ? null : idSet.get(pid);
     modelWrappers.forEach(el => {
       const mid = el.getAttribute('data-model-id');
-      const show = !ids || ids.has(mid);
+      let show;
+      if (!ids) { show = true; }
+      else if (ids.has(mid)) { show = true; }
+      else if (MEMO_TABLES[mid]) {
+        show = MEMO_TABLES[mid].some(tid => ids.has(tid));
+      } else { show = false; }
       el.style.opacity = show ? '' : '0';
       el.style.pointerEvents = show ? '' : 'none';
     });

--- a/src/features/canvas/ControlPanel.tsx
+++ b/src/features/canvas/ControlPanel.tsx
@@ -588,7 +588,7 @@ html, body { width: 100%; height: 100%; overflow: hidden; background: #f5f5f5; }
     const mx = e.clientX - rect.left, my = e.clientY - rect.top;
     const wx = (mx - panX) / scale, wy = (my - panY) / scale;
     const d = e.deltaY > 0 ? 0.9 : 1.1;
-    scale = Math.max(0.05, Math.min(5, scale * d));
+    scale = Math.max(0.05, Math.min(50, scale * d));
     panX = mx - wx * scale; panY = my - wy * scale;
     applyTransform();
   }, { passive: false });
@@ -597,7 +597,7 @@ html, body { width: 100%; height: 100%; overflow: hidden; background: #f5f5f5; }
     const rect = viewport.getBoundingClientRect();
     const cx = rect.width/2, cy = rect.height/2;
     const wx = (cx-panX)/scale, wy = (cy-panY)/scale;
-    scale = Math.min(5, scale*1.25); panX = cx-wx*scale; panY = cy-wy*scale; applyTransform();
+    scale = Math.min(50, scale*1.25); panX = cx-wx*scale; panY = cy-wy*scale; applyTransform();
   });
   document.getElementById('zoom-out').addEventListener('click', () => {
     const rect = viewport.getBoundingClientRect();

--- a/src/features/canvas/ErdRelationPathView.tsx
+++ b/src/features/canvas/ErdRelationPathView.tsx
@@ -675,7 +675,9 @@ const useStraightLineView = (
         return {
             tableIds: [relationModel.parentTableModelId, relationModel.childTableModelId],
             path: (
-                <g key={`relation-line_${relationView.relationId}`}>
+                <g key={`relation-line_${relationView.relationId}`}
+                    data-parent={relationModel.parentTableModelId}
+                    data-child={relationModel.childTableModelId}>
                     <path d={lineSegment.drawingPath} fill="none"
                         stroke={lineViewModel.color.toRgba()}
                         strokeWidth={lineViewModel.strokeWidth}
@@ -886,7 +888,9 @@ const useOrthogonalLine = (
         return {
             tableIds: [relationModel.parentTableModelId, relationModel.childTableModelId],
             path: (
-                <g key={`relation-line_${relationView.relationId}`}>
+                <g key={`relation-line_${relationView.relationId}`}
+                    data-parent={relationModel.parentTableModelId}
+                    data-child={relationModel.childTableModelId}>
                     <path d={drawingLine} fill="none"
                         stroke={relationView.lineViewModel.color.toRgba()}
                         strokeWidth={relationView.lineViewModel.strokeWidth}

--- a/src/features/canvas/RelationLabelOverlay.tsx
+++ b/src/features/canvas/RelationLabelOverlay.tsx
@@ -361,7 +361,10 @@ const RelationLabelOverlay = ({ labelData, selected }: RelationLabelOverlayProps
                     }} />
                 </>
             )}
-            <div ref={labelRef} style={{
+            <div ref={labelRef}
+                data-parent={relationView.relationModel.parentTableModelId}
+                data-child={relationView.relationModel.childTableModelId}
+                style={{
                 position: "absolute",
                 left: `${left}px`,
                 top: `${top}px`,


### PR DESCRIPTION
## Summary

- Adds **Save as interactive HTML** to the File menu (alongside existing PNG export)
- Exported HTML is self-contained — opens in any browser, no dependencies
- Snapshots the editor DOM rather than re-rendering, so positions, colors, and routing match exactly

## Features

- Pan (drag) & zoom (scroll wheel, +/- buttons, Fit, Cmd+0)
- Perspective switching via dropdown, arrow keys cycle through perspectives
- Table search (press `/` to focus)
- Relations and labels filtered by perspective using `data-parent`/`data-child` attributes

## Files changed

| File | Change |
|------|--------|
| `ControlPanel.tsx` | `downloadHtml` function, menu item, clone cleanup, viewer JS |
| `ErdRelationPathView.tsx` | `data-parent`/`data-child` on SVG `<g>` groups |
| `RelationLabelOverlay.tsx` | `data-parent`/`data-child` on label divs |

The data attributes on SVG groups and labels are no-ops for the editor — they only matter for the exported HTML's perspective filtering.

Closes #167.

## Test plan

- [ ] Open an ERD in VS Code, File → Save as interactive HTML
- [ ] Open the HTML in a browser — verify tables, memos, connections match the editor
- [ ] Switch perspectives — only relevant tables, connections, and labels visible
- [ ] Pan, zoom, Fit, search all work
- [ ] Verify "All" perspective shows everything

🤖 Generated with [Claude Code](https://claude.com/claude-code)