### PR TITLE
feat: export ERD as interactive SVG

### DIFF
--- a/src/features/canvas/ControlPanel.tsx
+++ b/src/features/canvas/ControlPanel.tsx
@@ -285,6 +285,13 @@ const SubMenuPanel = ({ erdExportable }: SubMenuButtonProps) => {
         handleCloseMenu();
     };
 
+    const handleSaveAsHtml = () => {
+        dispatchSelectAction(RELEASE_ACTION);
+
+        downloadHtml(erdDocument);
+        handleCloseMenu();
+    };
+
     const handleBatchExportPerspectives = () => {
         dispatchSelectAction(RELEASE_ACTION);
 
@@ -331,6 +338,7 @@ const SubMenuPanel = ({ erdExportable }: SubMenuButtonProps) => {
                 slotProps={{ paper: { 'aria-labelledby': 'basic-button', } }}>
                 <MenuItem onClick={() => setSelectedMenu("export_ddl")}>Export DDL</MenuItem>
                 <MenuItem onClick={handleSaveAsImage}>Save as image</MenuItem>
+                <MenuItem onClick={handleSaveAsHtml}>Save as interactive HTML</MenuItem>
                 <MenuItem onClick={handleBatchExportPerspectives}
                     disabled={erdDocument.erdSettingModel.getPerspectiveModels().length === 0}>
                     Export all perspectives as images
@@ -361,6 +369,259 @@ const downloadImage = (erdDocument: ErdDocument) => {
 
         download(fileName, contents.base64Value);
     });
+};
+
+const downloadHtml = (erdDocument: ErdDocument) => {
+    const erdCanvas = document.getElementById("erd-canvas");
+    if (erdCanvas == null) return;
+
+    const orgScale = erdCanvas.style.transform;
+    erdCanvas.style.transform = "scale(1)";
+
+    const { leftEdge, topEdge, rightEdge, bottomEdge } = doCalculateImageArea(erdCanvas);
+    const pad = 100;
+    const cropX = leftEdge - pad;
+    const cropY = topEdge - pad;
+    const contentW = rightEdge - leftEdge + pad * 2;
+    const contentH = bottomEdge - topEdge + pad * 2;
+
+    const clone = erdCanvas.cloneNode(true) as HTMLElement;
+
+    clone.removeAttribute("id");
+    clone.style.transform = "none";
+    clone.style.position = "absolute";
+    clone.style.left = "0";
+    clone.style.top = "0";
+
+    clone.querySelectorAll("[id='toolbar-portal'], [id='relation-toolbar-container']").forEach(el => el.remove());
+    clone.querySelectorAll(".MuiPopover-root, .MuiPopper-root").forEach(el => el.remove());
+
+    // Reset perspective-hidden elements and propagate model IDs to wrappers for JS filtering.
+    // The editor sets opacity/pointerEvents on the PARENT wrapper, not the .erdTableView/.erdMemoView itself.
+    // Also copy the id to a data-model-id on the wrapper so JS can filter by wrapper directly.
+    clone.querySelectorAll('.erdTableView, .erdMemoView').forEach(el => {
+        const wrapper = (el as HTMLElement).parentElement;
+        if (wrapper) {
+            wrapper.style.opacity = '';
+            wrapper.style.pointerEvents = '';
+            wrapper.setAttribute('data-model-id', (el as HTMLElement).id);
+        }
+    });
+    // Memo wrappers have z-index:-100 which puts them behind the white canvas background.
+    // Raise them to z-index:0 so they're visible but still behind tables.
+    clone.querySelectorAll('.erdMemoView').forEach(el => {
+        const wrapper = (el as HTMLElement).parentElement;
+        if (wrapper) {
+            wrapper.style.zIndex = '0';
+        }
+    });
+
+    // SVG <g> groups and label divs already have data-parent/data-child from React render.
+
+    const sheets = Array.from(document.styleSheets);
+    let inlinedCss = "";
+    for (const sheet of sheets) {
+        try {
+            const rules = sheet.cssRules || sheet.rules;
+            for (const rule of Array.from(rules)) {
+                inlinedCss += rule.cssText + "\n";
+            }
+        } catch (_) { /* cross-origin sheets */ }
+    }
+
+    const perspectives = erdDocument.erdSettingModel.getPerspectiveModels();
+    const perspJson = JSON.stringify(perspectives.map(p => ({
+        id: p.perspectiveId,
+        name: p.perspectiveName,
+        ids: p.getContainIds()
+    })));
+
+    const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>${erdDocument.documentName}</title>
+<meta name="export-id" content="${crypto.randomUUID()}">
+<style>
+${inlinedCss}
+* { margin: 0; padding: 0; box-sizing: border-box; }
+html, body { width: 100%; height: 100%; overflow: hidden; background: #f5f5f5; }
+#toolbar {
+  position: fixed !important; top: 0 !important; left: 0 !important; right: 0 !important; z-index: 10000 !important;
+  display: flex !important; align-items: center !important; gap: 12px !important;
+  padding: 8px 16px !important; background: #fff !important; border-bottom: 1px solid #ddd !important;
+  box-shadow: 0 1px 3px rgba(0,0,0,0.1) !important; font-size: 13px !important;
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif !important;
+  color: #333 !important; visibility: visible !important; opacity: 1 !important;
+}
+#toolbar * { visibility: visible !important; opacity: 1 !important; color: inherit !important; }
+#toolbar label { font-weight: 600 !important; color: #444 !important; }
+#toolbar select { padding: 4px 8px !important; border-radius: 4px !important; border: 1px solid #ccc !important; font-size: 13px !important; max-width: 340px !important; background: #fff !important; color: #333 !important; }
+#toolbar .zoom-controls { display: flex !important; align-items: center !important; gap: 4px !important; margin-left: auto !important; }
+#toolbar button { padding: 4px 10px !important; border: 1px solid #ccc !important; border-radius: 4px !important; background: #fff !important; cursor: pointer !important; font-size: 13px !important; color: #333 !important; }
+#toolbar button:hover { background: #f0f0f0 !important; }
+#zoom-display { min-width: 44px !important; text-align: center !important; color: #333 !important; }
+#toolbar .title { font-weight: 700 !important; color: #333 !important; font-size: 14px !important; }
+#search-box { padding: 4px 8px !important; border-radius: 4px !important; border: 1px solid #ccc !important; font-size: 13px !important; width: 180px !important; background: #fff !important; color: #333 !important; }
+#viewport { position: absolute; top: 42px; left: 0; right: 0; bottom: 0; overflow: hidden; cursor: grab; }
+#viewport.grabbing { cursor: grabbing; }
+#canvas-wrapper { position: absolute; transform-origin: 0 0; }
+.search-highlight { outline: 3px solid #ff6b00 !important; outline-offset: 2px; z-index: 10000 !important; }
+</style>
+</head>
+<body>
+<div id="toolbar">
+  <span class="title">${erdDocument.documentName}</span>
+  <label for="perspective-select">Perspective:</label>
+  <select id="perspective-select">
+    <option value="all" selected>All</option>
+  </select>
+  <input id="search-box" type="text" placeholder="Search tables...">
+  <div class="zoom-controls">
+    <button id="zoom-out">\u2212</button>
+    <span id="zoom-display">100%</span>
+    <button id="zoom-in">+</button>
+    <button id="zoom-fit">Fit</button>
+  </div>
+</div>
+<div id="viewport">
+  <div id="canvas-wrapper">
+    ${clone.outerHTML}
+  </div>
+</div>
+<script>
+(function() {
+  const viewport = document.getElementById('viewport');
+  const wrapper = document.getElementById('canvas-wrapper');
+  const perspSelect = document.getElementById('perspective-select');
+  const searchBox = document.getElementById('search-box');
+  const zoomDisplay = document.getElementById('zoom-display');
+  const cropX = ${cropX}, cropY = ${cropY};
+  const contentW = ${contentW}, contentH = ${contentH};
+  const PERSPECTIVES = ${perspJson};
+
+  PERSPECTIVES.forEach(p => {
+    const opt = document.createElement('option');
+    opt.value = p.id;
+    opt.textContent = p.name;
+    perspSelect.appendChild(opt);
+  });
+
+  const idSet = new Map();
+  PERSPECTIVES.forEach(p => idSet.set(p.id, new Set(p.ids)));
+
+  let scale = 1, panX = 0, panY = 0;
+  let isPanning = false, startX = 0, startY = 0, startPanX = 0, startPanY = 0;
+
+  function applyTransform() {
+    wrapper.style.transform = 'translate(' + panX + 'px,' + panY + 'px) scale(' + scale + ')';
+    zoomDisplay.textContent = Math.round(scale * 100) + '%';
+  }
+
+  function fitAll() {
+    const vw = viewport.clientWidth, vh = viewport.clientHeight;
+    scale = Math.min(vw / contentW, vh / contentH, 2) * 0.95;
+    panX = (vw - contentW * scale) / 2 - cropX * scale;
+    panY = (vh - contentH * scale) / 2 - cropY * scale;
+    applyTransform();
+  }
+
+  fitAll();
+
+  viewport.addEventListener('mousedown', e => {
+    if (e.button !== 0) return;
+    isPanning = true; startX = e.clientX; startY = e.clientY;
+    startPanX = panX; startPanY = panY;
+    viewport.classList.add('grabbing');
+  });
+  window.addEventListener('mousemove', e => {
+    if (!isPanning) return;
+    panX = startPanX + e.clientX - startX;
+    panY = startPanY + e.clientY - startY;
+    applyTransform();
+  });
+  window.addEventListener('mouseup', () => { isPanning = false; viewport.classList.remove('grabbing'); });
+
+  viewport.addEventListener('wheel', e => {
+    e.preventDefault();
+    const rect = viewport.getBoundingClientRect();
+    const mx = e.clientX - rect.left, my = e.clientY - rect.top;
+    const wx = (mx - panX) / scale, wy = (my - panY) / scale;
+    const d = e.deltaY > 0 ? 0.9 : 1.1;
+    scale = Math.max(0.05, Math.min(5, scale * d));
+    panX = mx - wx * scale; panY = my - wy * scale;
+    applyTransform();
+  }, { passive: false });
+
+  document.getElementById('zoom-in').addEventListener('click', () => {
+    const rect = viewport.getBoundingClientRect();
+    const cx = rect.width/2, cy = rect.height/2;
+    const wx = (cx-panX)/scale, wy = (cy-panY)/scale;
+    scale = Math.min(5, scale*1.25); panX = cx-wx*scale; panY = cy-wy*scale; applyTransform();
+  });
+  document.getElementById('zoom-out').addEventListener('click', () => {
+    const rect = viewport.getBoundingClientRect();
+    const cx = rect.width/2, cy = rect.height/2;
+    const wx = (cx-panX)/scale, wy = (cy-panY)/scale;
+    scale = Math.max(0.05, scale/1.25); panX = cx-wx*scale; panY = cy-wy*scale; applyTransform();
+  });
+  document.getElementById('zoom-fit').addEventListener('click', fitAll);
+
+  function applyPerspective(pid) {
+    const modelWrappers = wrapper.querySelectorAll('[data-model-id]');
+    const relElements = wrapper.querySelectorAll('[data-parent]');
+    const ids = pid === 'all' ? null : idSet.get(pid);
+    modelWrappers.forEach(el => {
+      const mid = el.getAttribute('data-model-id');
+      const show = !ids || ids.has(mid);
+      el.style.opacity = show ? '' : '0';
+      el.style.pointerEvents = show ? '' : 'none';
+    });
+    relElements.forEach(el => {
+      const p = el.getAttribute('data-parent');
+      const c = el.getAttribute('data-child');
+      const show = !ids || (ids.has(p) && ids.has(c));
+      el.style.display = show ? '' : 'none';
+      el.setAttribute('visibility', show ? 'visible' : 'hidden');
+    });
+  }
+
+  perspSelect.addEventListener('change', () => applyPerspective(perspSelect.value));
+
+  searchBox.addEventListener('input', () => {
+    const q = searchBox.value.toLowerCase().trim();
+    wrapper.querySelectorAll('.search-highlight').forEach(el => el.classList.remove('search-highlight'));
+    if (!q) return;
+    wrapper.querySelectorAll('.erdTableView').forEach(el => {
+      const header = el.querySelector('[class*="header"], div:first-child');
+      if (header && header.textContent.toLowerCase().includes(q)) el.classList.add('search-highlight');
+    });
+  });
+
+  document.addEventListener('keydown', e => {
+    if (e.key === '0' && (e.metaKey || e.ctrlKey)) { e.preventDefault(); fitAll(); }
+    if (e.key === '=' && (e.metaKey || e.ctrlKey)) { e.preventDefault(); document.getElementById('zoom-in').click(); }
+    if (e.key === '-' && (e.metaKey || e.ctrlKey)) { e.preventDefault(); document.getElementById('zoom-out').click(); }
+    if (e.key === '/' && !e.metaKey && !e.ctrlKey) { e.preventDefault(); searchBox.focus(); }
+    if (e.key === 'Escape') { searchBox.blur(); searchBox.value = ''; searchBox.dispatchEvent(new Event('input')); }
+    if ((e.key === 'ArrowDown' || e.key === 'ArrowUp') && document.activeElement !== searchBox) {
+      e.preventDefault();
+      const opts = perspSelect.options;
+      const dir = e.key === 'ArrowDown' ? 1 : -1;
+      const next = perspSelect.selectedIndex + dir;
+      if (next >= 0 && next < opts.length) { perspSelect.selectedIndex = next; perspSelect.dispatchEvent(new Event('change')); }
+    }
+  });
+})();
+</script>
+</body>
+</html>`;
+
+    erdCanvas.style.transform = orgScale;
+
+    const blob = new Blob([html], { type: "text/html" });
+    const fileName = `${erdDocument.documentName}.html`;
+    download(fileName, blob);
 };
 
 const downloadSpecification = (

--- a/src/features/canvas/ControlPanel.tsx
+++ b/src/features/canvas/ControlPanel.tsx
@@ -30,6 +30,7 @@ import { ERD_MEMO_VIEW_CLASS_NAME } from "~/features/canvas/StickyMemoView";
 import ExportSpecificationContext, { ImageContent } from "~/context/ExportSpecificationContext";
 import DescriptionTooltip from "~/features/canvas/DescriptionTooltip";
 import { DRAWABLE_AREA, getScroll } from "~/features/canvas/support";
+import { overrideColumnName } from "~/models/database/support";
 
 type ControlPanelProps = {
     erdExportable: boolean
@@ -292,6 +293,13 @@ const SubMenuPanel = ({ erdExportable }: SubMenuButtonProps) => {
         handleCloseMenu();
     };
 
+    const handleSaveAsSvg = () => {
+        dispatchSelectAction(RELEASE_ACTION);
+
+        downloadSvg(erdDocument);
+        handleCloseMenu();
+    };
+
     const handleBatchExportPerspectives = () => {
         dispatchSelectAction(RELEASE_ACTION);
 
@@ -339,6 +347,7 @@ const SubMenuPanel = ({ erdExportable }: SubMenuButtonProps) => {
                 <MenuItem onClick={() => setSelectedMenu("export_ddl")}>Export DDL</MenuItem>
                 <MenuItem onClick={handleSaveAsImage}>Save as image</MenuItem>
                 <MenuItem onClick={handleSaveAsHtml}>Save as interactive HTML</MenuItem>
+                <MenuItem onClick={handleSaveAsSvg}>Save as interactive SVG</MenuItem>
                 <MenuItem onClick={handleBatchExportPerspectives}
                     disabled={erdDocument.erdSettingModel.getPerspectiveModels().length === 0}>
                     Export all perspectives as images
@@ -426,7 +435,7 @@ const downloadHtml = (erdDocument: ErdDocument) => {
             for (const rule of Array.from(rules)) {
                 inlinedCss += rule.cssText + "\n";
             }
-        } catch (_) { /* cross-origin sheets */ }
+        } catch { /* cross-origin sheets */ }
     }
 
     const perspectives = erdDocument.erdSettingModel.getPerspectiveModels();
@@ -666,6 +675,468 @@ html, body { width: 100%; height: 100%; overflow: hidden; background: #f5f5f5; }
 
     const blob = new Blob([html], { type: "text/html" });
     const fileName = `${erdDocument.documentName}.html`;
+    download(fileName, blob);
+};
+
+const escSvg = (s: string) => s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+
+const downloadSvg = (erdDocument: ErdDocument) => {
+    const erdCanvas = document.getElementById("erd-canvas");
+    if (erdCanvas == null) return;
+
+    const displayStyle = erdDocument.getDisplayStyle();
+    const tableViewModels = erdDocument.getTableViewModels();
+    const relationViewModels = erdDocument.getRelationViewModels();
+    const { frontMemos, backMemos } = erdDocument.getMemoViewModels();
+    const allMemos = [...backMemos, ...frontMemos];
+
+    const perspectives = erdDocument.erdSettingModel.getPerspectiveModels();
+    const perspJson = JSON.stringify(perspectives.map(p => ({
+        id: p.perspectiveId,
+        name: p.perspectiveName,
+        ids: p.getContainIds()
+    })));
+
+    const COL_PAD = 8;
+    const FONT_SIZE = 12;
+    const HEADER_FONT = 13;
+    const BORDER_RADIUS = 10;
+    const FALLBACK_HEADER_H = 28;
+    const FALLBACK_ROW_H = 24;
+
+    const svgTables: string[] = [];
+    const tableRects: { id: string, x: number, y: number, w: number, h: number }[] = [];
+
+    let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
+
+    for (const tvm of tableViewModels) {
+        const tm = tvm.tableModel;
+        const allColumns = erdDocument.toAllColumnModels(tm);
+        const tableName = displayStyle.displayName(tm.physicalName, tm.logicalName);
+        const bgHex = tvm.headerColor.background.toHex();
+        const fgHex = tvm.headerColor.foreground.toHex();
+
+        const domEl = document.getElementById(tvm.tableId);
+        const tableW = domEl ? domEl.offsetWidth : 220;
+        const tableH = domEl ? domEl.offsetHeight : FALLBACK_HEADER_H + allColumns.length * FALLBACK_ROW_H + 4;
+
+        const domTrs = domEl ? domEl.querySelectorAll("tr") : null;
+        const headerH = (() => {
+            if (!domEl) return FALLBACK_HEADER_H;
+            const hdrEl = domEl.querySelector("table")?.parentElement?.previousElementSibling as HTMLElement | null;
+            return hdrEl ? hdrEl.offsetHeight : FALLBACK_HEADER_H;
+        })();
+
+        const rowHeights: number[] = [];
+        if (domTrs && domTrs.length > 0) {
+            domTrs.forEach(tr => rowHeights.push((tr as HTMLElement).offsetHeight));
+        } else {
+            for (let i = 0; i < allColumns.length; i++) rowHeights.push(FALLBACK_ROW_H);
+        }
+
+        const x = tvm.corner.left + DRAWABLE_AREA.width / 2;
+        const y = tvm.corner.top + DRAWABLE_AREA.height / 2;
+        tableRects.push({ id: tvm.tableId, x, y, w: tableW, h: tableH });
+        minX = Math.min(minX, x); minY = Math.min(minY, y);
+        maxX = Math.max(maxX, x + tableW); maxY = Math.max(maxY, y + tableH);
+
+        const fkColumnIds = new Set<string>();
+        for (const rv of relationViewModels) {
+            if (rv.childTableModelId === tm.tableModelId) {
+                for (const pair of rv.relationModel.relationPairs) {
+                    fkColumnIds.add(pair.childColumnModelId);
+                }
+            }
+        }
+
+        let colWidths = { pk: 20, fk: 20, name: 100, type: 80, opt: 40 };
+        if (domTrs && domTrs.length > 0) {
+            const cells = domTrs[0].querySelectorAll("td");
+            if (cells.length >= 5) {
+                colWidths = {
+                    pk: (cells[0] as HTMLElement).offsetWidth,
+                    fk: (cells[1] as HTMLElement).offsetWidth,
+                    name: (cells[2] as HTMLElement).offsetWidth,
+                    type: (cells[3] as HTMLElement).offsetWidth,
+                    opt: (cells[4] as HTMLElement).offsetWidth
+                };
+            }
+        }
+
+        let rows = "";
+        let cumulY = headerH;
+        for (let ci = 0; ci < allColumns.length; ci++) {
+            const col = allColumns[ci];
+            const shareModel = erdDocument.findColumnShareModel(col.columnShareModelId);
+            if (!shareModel) continue;
+            const names = overrideColumnName(col, shareModel);
+            const colName = displayStyle.displayName(names.physicalName, names.logicalName);
+            const colType = shareModel.specifiedColumnType(
+                erdDocument.inChildRelation(tm.tableModelId, col.columnModelId)
+            );
+            const opts: string[] = [];
+            if (col.notNull) opts.push("NN");
+            if (col.unique) opts.push("U");
+            const optStr = opts.length > 0 ? `(${opts.join(",")})` : "";
+
+            const rh = rowHeights[ci] ?? FALLBACK_ROW_H;
+            const textY = cumulY + rh * 0.68;
+
+            let xOff = COL_PAD;
+            let pkIcon = "";
+            if (col.primaryKey) {
+                pkIcon = `<text x="${xOff + 2}" y="${textY}" fill="#90292F" font-size="10" font-family="monospace">PK</text>`;
+            }
+            xOff += colWidths.pk;
+
+            let fkIcon = "";
+            if (fkColumnIds.has(col.columnModelId)) {
+                fkIcon = `<text x="${xOff + 2}" y="${textY}" fill="#212490" font-size="10" font-family="monospace">FK</text>`;
+            }
+            xOff += colWidths.fk;
+
+            const nameColor = col.primaryKey ? "#90292F" : (fkColumnIds.has(col.columnModelId) ? "#212490" : "#333");
+            const nameEl = `<text x="${xOff}" y="${textY}" fill="${nameColor}" font-size="${FONT_SIZE}" font-family="sans-serif">${escSvg(colName)}</text>`;
+            xOff += colWidths.name;
+
+            const typeEl = `<text x="${xOff}" y="${textY}" fill="#666" font-size="11" font-family="sans-serif">${escSvg(colType)}</text>`;
+            xOff += colWidths.type;
+
+            const optEl = optStr ? `<text x="${xOff}" y="${textY}" fill="#888" font-size="11" font-family="sans-serif">${escSvg(optStr)}</text>` : "";
+
+            if (ci > 0) {
+                rows += `<line x1="0" y1="${cumulY}" x2="${tableW}" y2="${cumulY}" stroke="#e0e0e0" stroke-width="0.5"/>`;
+            }
+            rows += pkIcon + fkIcon + nameEl + typeEl + optEl;
+            cumulY += rh;
+        }
+
+        svgTables.push(`<g data-model-id="${tvm.tableId}" transform="translate(${x}, ${y})">
+  <rect width="${tableW}" height="${tableH}" rx="${BORDER_RADIUS}" fill="#FDFDFD" stroke="#bbb" stroke-width="1.5"/>
+  <clipPath id="clip-hdr-${tvm.tableId}"><rect width="${tableW}" height="${headerH}" rx="${BORDER_RADIUS}"/></clipPath>
+  <rect width="${tableW}" height="${headerH}" fill="${bgHex}" clip-path="url(#clip-hdr-${tvm.tableId})"/>
+  <rect x="0" y="${headerH - BORDER_RADIUS}" width="${tableW}" height="${BORDER_RADIUS}" fill="${bgHex}"/>
+  <text x="${COL_PAD}" y="${headerH * 0.68}" fill="${fgHex}" font-size="${HEADER_FONT}" font-weight="600" font-family="sans-serif">${escSvg(tableName)}</text>
+  <line x1="0" y1="${headerH}" x2="${tableW}" y2="${headerH}" stroke="#999" stroke-width="1"/>
+  ${rows}
+</g>`);
+    }
+
+    const svgMemos: string[] = [];
+    for (const memo of allMemos) {
+        const rect = memo.rectangleViewModel;
+        const mx = rect.positionX + DRAWABLE_AREA.width / 2;
+        const my = rect.positionY + DRAWABLE_AREA.height / 2;
+        minX = Math.min(minX, mx); minY = Math.min(minY, my);
+        maxX = Math.max(maxX, mx + rect.width); maxY = Math.max(maxY, my + rect.height);
+
+        const bgHex = memo.backgroundColor.toHex();
+        const fgHex = memo.foregroundColor.toHex();
+        const fontSize = memo.fontSize;
+
+        const lines = memo.memo.split("\n");
+        const lineHeight = fontSize * 1.4;
+        let textAnchor = "start";
+        let textX = 10;
+        if (memo.horizontalAlign === "center") { textAnchor = "middle"; textX = rect.width / 2; }
+        else if (memo.horizontalAlign === "end") { textAnchor = "end"; textX = rect.width - 10; }
+
+        let startY: number;
+        const totalTextH = lines.length * lineHeight;
+        if (memo.verticalAlign === "start") startY = lineHeight;
+        else if (memo.verticalAlign === "end") startY = rect.height - totalTextH + lineHeight;
+        else startY = (rect.height - totalTextH) / 2 + lineHeight;
+
+        const textEls = lines.map((line, i) =>
+            `<text x="${textX}" y="${startY + i * lineHeight}" fill="${fgHex}" font-size="${fontSize}" font-family="sans-serif" text-anchor="${textAnchor}">${escSvg(line)}</text>`
+        ).join("\n  ");
+
+        svgMemos.push(`<g data-model-id="${memo.memoId}" transform="translate(${mx}, ${my})">
+  <rect width="${rect.width}" height="${rect.height}" fill="${bgHex}" rx="2"/>
+  ${textEls}
+</g>`);
+    }
+
+    const renderedSvg = erdCanvas.querySelector("svg");
+    let defsContent = "";
+    let connectionGroups = "";
+    let labelGroups = "";
+
+    if (renderedSvg) {
+        const defs = renderedSvg.querySelector("defs");
+        if (defs) defsContent = defs.innerHTML;
+
+        renderedSvg.querySelectorAll("g[data-parent]").forEach(g => {
+            connectionGroups += g.outerHTML + "\n";
+        });
+    }
+
+    erdCanvas.querySelectorAll("div[data-parent]").forEach(el => {
+        const htmlEl = el as HTMLElement;
+        const parent = htmlEl.getAttribute("data-parent") ?? "";
+        const child = htmlEl.getAttribute("data-child") ?? "";
+        const text = htmlEl.textContent ?? "";
+        if (!text) return;
+        const style = htmlEl.style;
+        const lx = parseFloat(style.left) || 0;
+        const ly = parseFloat(style.top) || 0;
+        const fs = parseFloat(style.fontSize) || 13;
+        const color = style.color || "rgba(60,60,60,0.95)";
+        const fw = style.fontWeight || "400";
+        const fst = style.fontStyle === "italic" ? "italic" : "normal";
+        const dec = style.textDecoration?.includes("line-through") ? "line-through" : "none";
+
+        labelGroups += `<text data-parent="${escSvg(parent)}" data-child="${escSvg(child)}" x="${lx}" y="${ly + fs}" fill="${color}" font-size="${fs}" font-weight="${fw}" font-style="${fst}" text-decoration="${dec}" font-family="sans-serif">${escSvg(text)}</text>\n`;
+    });
+
+    const memoTableMap: Record<string, string[]> = {};
+    for (const memo of allMemos) {
+        const r = memo.rectangleViewModel;
+        const mx = r.positionX + DRAWABLE_AREA.width / 2;
+        const my = r.positionY + DRAWABLE_AREA.height / 2;
+        const contained = tableRects
+            .filter(t => t.x >= mx && t.y >= my && t.x + t.w <= mx + r.width && t.y + t.h <= my + r.height)
+            .map(t => t.id);
+        if (contained.length > 0) memoTableMap[memo.memoId] = contained;
+    }
+    const memoTableJson = JSON.stringify(memoTableMap);
+
+    const pad = 100;
+    const vbX = minX - pad;
+    const vbY = minY - pad;
+    const vbW = maxX - minX + pad * 2;
+    const vbH = maxY - minY + pad * 2;
+
+    const perspOptions = perspectives.map(p => `<option value="${escSvg(p.perspectiveId)}">${escSvg(p.perspectiveName)}</option>`).join("");
+
+    const svgContent = `<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg"
+     viewBox="${vbX} ${vbY} ${vbW} ${vbH}" preserveAspectRatio="none" style="background:#f5f5f5;width:100vw;height:100vh;display:block">
+<defs>
+${defsContent}
+<style>
+  .search-highlight rect:first-child { stroke: #ff6b00 !important; stroke-width: 3 !important; }
+</style>
+</defs>
+<g id="erd-content">
+  <g id="memo-layer">${svgMemos.join("\n")}</g>
+  <g id="connection-layer">${connectionGroups}</g>
+  <g id="label-layer">${labelGroups}</g>
+  <g id="table-layer">${svgTables.join("\n")}</g>
+</g>
+<g id="ui-overlay">
+  <rect id="toolbar-bg" x="0" y="0" width="714" height="42" fill="#fff" stroke="#ddd" stroke-width="1" rx="6"/>
+  <text id="title-text" x="14" y="27" font-size="16" font-weight="700" fill="#333" font-family="sans-serif">${escSvg(erdDocument.documentName)}</text>
+  <text x="250" y="27" font-size="14" fill="#444" font-weight="600" font-family="sans-serif">Perspective:</text>
+  <foreignObject x="338" y="6" width="220" height="32">
+    <div xmlns="http://www.w3.org/1999/xhtml">
+      <select id="persp-select" style="width:210px;height:28px;font-size:14px;border:1px solid #ccc;border-radius:4px;padding:2px 6px;background:#fff;color:#333;font-family:sans-serif">
+        <option value="all" selected="selected">All</option>
+        ${perspOptions}
+      </select>
+    </div>
+  </foreignObject>
+  <g id="zoom-out-btn" cursor="pointer"><rect x="570" y="7" width="28" height="28" fill="#fff" stroke="#ccc" rx="4"/><text x="579" y="27" font-size="18" fill="#333" font-family="sans-serif">\u2212</text></g>
+  <text id="zoom-display" x="604" y="27" font-size="14" fill="#333" font-family="sans-serif">100%</text>
+  <g id="zoom-in-btn" cursor="pointer"><rect width="28" height="28" fill="#fff" stroke="#ccc" rx="4"/><text x="8" y="20" font-size="18" fill="#333" font-family="sans-serif">+</text></g>
+  <g id="zoom-fit-btn" cursor="pointer"><rect width="34" height="28" fill="#fff" stroke="#ccc" rx="4"/><text x="7" y="20" font-size="14" fill="#333" font-family="sans-serif">Fit</text></g>
+</g>
+<script type="text/ecmascript"><![CDATA[
+(function() {
+  var svg = document.documentElement;
+  var content = document.getElementById('erd-content');
+  var overlay = document.getElementById('ui-overlay');
+  var perspSelect = document.getElementById('persp-select');
+  var zoomDisp = document.getElementById('zoom-display');
+  var zoomInBtn = document.getElementById('zoom-in-btn');
+  var zoomFitBtn = document.getElementById('zoom-fit-btn');
+  var toolbarBg = document.getElementById('toolbar-bg');
+  var PERSPECTIVES = ${perspJson};
+  var MEMO_TABLES = ${memoTableJson};
+
+  var vbX = ${vbX}, vbY = ${vbY}, vbW = ${vbW}, vbH = ${vbH};
+  var curVbX = vbX, curVbY = vbY, curVbW = vbW, curVbH = vbH;
+
+  var idSets = {};
+  PERSPECTIVES.forEach(function(p) {
+    var s = {}; p.ids.forEach(function(id) { s[id] = true; }); idSets[p.id] = s;
+  });
+
+  function layoutZoomControls() {
+    var bbox = zoomDisp.getBBox();
+    var afterText = bbox.x + bbox.width + 6;
+    zoomInBtn.setAttribute('transform', 'translate(' + afterText + ',7)');
+    var fitX = afterText + 36;
+    zoomFitBtn.setAttribute('transform', 'translate(' + fitX + ',7)');
+    toolbarBg.setAttribute('width', String(fitX + 42));
+  }
+
+  function updateViewBox() {
+    svg.setAttribute('viewBox', curVbX + ' ' + curVbY + ' ' + curVbW + ' ' + curVbH);
+    var pct = Math.round((vbW / curVbW) * 100);
+    zoomDisp.textContent = pct + '%';
+    layoutZoomControls();
+    positionOverlay();
+  }
+
+  function matchAspect() {
+    var sw = window.innerWidth || 800;
+    var sh = window.innerHeight || 600;
+    var viewportRatio = sw / sh;
+    var vbRatio = curVbW / curVbH;
+    if (viewportRatio > vbRatio) {
+      var newW = curVbH * viewportRatio;
+      curVbX -= (newW - curVbW) / 2;
+      curVbW = newW;
+    } else {
+      var newH = curVbW / viewportRatio;
+      curVbY -= (newH - curVbH) / 2;
+      curVbH = newH;
+    }
+  }
+
+  function positionOverlay() {
+    var sw = window.innerWidth || 800;
+    var s = curVbW / sw;
+    var tbW = parseFloat(toolbarBg.getAttribute('width')) || 714;
+    var toolbarW = tbW * s;
+    var offsetX = curVbX + (curVbW - toolbarW) / 2;
+    overlay.setAttribute('transform', 'translate(' + offsetX + ',' + curVbY + ') scale(' + s + ')');
+  }
+  window.addEventListener('resize', function() { matchAspect(); updateViewBox(); });
+
+  function visibleBBox() {
+    var models = content.querySelectorAll('[data-model-id]');
+    var mnX = Infinity, mnY = Infinity, mxX = -Infinity, mxY = -Infinity;
+    for (var i = 0; i < models.length; i++) {
+      if (models[i].getAttribute('visibility') === 'hidden') continue;
+      var tr = models[i].getAttribute('transform') || '';
+      var m = tr.match(/translate\\(([\\d.\\-]+),\\s*([\\d.\\-]+)\\)/);
+      if (!m) continue;
+      var tx = parseFloat(m[1]), ty = parseFloat(m[2]);
+      try { var b = models[i].getBBox(); } catch(e) { continue; }
+      if (b.width === 0 && b.height === 0) continue;
+      mnX = Math.min(mnX, tx + b.x); mnY = Math.min(mnY, ty + b.y);
+      mxX = Math.max(mxX, tx + b.x + b.width); mxY = Math.max(mxY, ty + b.y + b.height);
+    }
+    if (mnX === Infinity) return { x: vbX, y: vbY, w: vbW, h: vbH };
+    var pad = 100;
+    return { x: mnX - pad, y: mnY - pad, w: mxX - mnX + pad * 2, h: mxY - mnY + pad * 2 };
+  }
+
+  function fitAll() {
+    var bb = visibleBBox();
+    curVbX = bb.x; curVbY = bb.y; curVbW = bb.w; curVbH = bb.h;
+    matchAspect();
+    var tbH = 42 * (curVbW / (window.innerWidth || 800));
+    curVbY -= tbH / 2;
+    updateViewBox();
+  }
+
+  fitAll();
+
+  var isPanning = false, panClientX, panClientY, panVbX, panVbY;
+
+  svg.addEventListener('mousedown', function(e) {
+    if (e.target.closest('#ui-overlay')) return;
+    if (e.button !== 0) return;
+    e.preventDefault();
+    isPanning = true;
+    panClientX = e.clientX; panClientY = e.clientY;
+    panVbX = curVbX; panVbY = curVbY;
+    svg.style.cursor = 'grabbing';
+  });
+
+  svg.addEventListener('mousemove', function(e) {
+    if (!isPanning) return;
+    e.preventDefault();
+    var svgRect = svg.getBoundingClientRect();
+    var scaleX = curVbW / svgRect.width;
+    var scaleY = curVbH / svgRect.height;
+    curVbX = panVbX - (e.clientX - panClientX) * scaleX;
+    curVbY = panVbY - (e.clientY - panClientY) * scaleY;
+    updateViewBox();
+  });
+
+  svg.addEventListener('mouseup', function() { isPanning = false; svg.style.cursor = 'default'; });
+  svg.addEventListener('mouseleave', function() { isPanning = false; svg.style.cursor = 'default'; });
+
+  svg.addEventListener('wheel', function(e) {
+    e.preventDefault();
+    var pt = svg.createSVGPoint();
+    pt.x = e.clientX; pt.y = e.clientY;
+    var ctm = svg.getScreenCTM().inverse();
+    var svgPt = pt.matrixTransform(ctm);
+    var factor = e.deltaY > 0 ? 1.1 : 0.9;
+    var newW = curVbW * factor;
+    var newH = curVbH * factor;
+    curVbX = svgPt.x - (svgPt.x - curVbX) * factor;
+    curVbY = svgPt.y - (svgPt.y - curVbY) * factor;
+    curVbW = newW; curVbH = newH;
+    updateViewBox();
+  }, {passive: false});
+
+  function zoom(factor) {
+    var cx = curVbX + curVbW / 2, cy = curVbY + curVbH / 2;
+    curVbW *= factor; curVbH *= factor;
+    curVbX = cx - curVbW / 2; curVbY = cy - curVbH / 2;
+    updateViewBox();
+  }
+
+  document.getElementById('zoom-in-btn').addEventListener('click', function() { zoom(0.8); });
+  document.getElementById('zoom-out-btn').addEventListener('click', function() { zoom(1.25); });
+  document.getElementById('zoom-fit-btn').addEventListener('click', fitAll);
+
+  function applyPerspective(pid) {
+    var ids = pid === 'all' ? null : idSets[pid];
+    var models = content.querySelectorAll('[data-model-id]');
+    var rels = content.querySelectorAll('[data-parent]');
+    for (var i = 0; i < models.length; i++) {
+      var mid = models[i].getAttribute('data-model-id');
+      var show;
+      if (!ids) { show = true; }
+      else if (ids[mid]) { show = true; }
+      else if (MEMO_TABLES[mid]) {
+        show = MEMO_TABLES[mid].some(function(tid) { return ids[tid]; });
+      } else { show = false; }
+      models[i].setAttribute('visibility', show ? 'visible' : 'hidden');
+    }
+    for (var j = 0; j < rels.length; j++) {
+      var p = rels[j].getAttribute('data-parent');
+      var c = rels[j].getAttribute('data-child');
+      var showR = !ids || (ids[p] && ids[c]);
+      rels[j].setAttribute('visibility', showR ? 'visible' : 'hidden');
+    }
+  }
+
+  perspSelect.addEventListener('change', function() { applyPerspective(perspSelect.value); });
+
+  function perspStep(delta) {
+    var idx = perspSelect.selectedIndex + delta;
+    if (idx < 0 || idx >= perspSelect.options.length) return;
+    perspSelect.selectedIndex = idx;
+    applyPerspective(perspSelect.value);
+  }
+
+  document.addEventListener('keydown', function(e) {
+    if (e.key === '0' && (e.metaKey || e.ctrlKey)) { e.preventDefault(); fitAll(); }
+    if (e.key === '=' && (e.metaKey || e.ctrlKey)) { e.preventDefault(); zoom(0.8); }
+    if (e.key === '-' && (e.metaKey || e.ctrlKey)) { e.preventDefault(); zoom(1.25); }
+    if (e.key === 'ArrowDown' || e.key === 'ArrowRight') {
+      if (document.activeElement === perspSelect) return;
+      e.preventDefault(); perspStep(1);
+    }
+    if (e.key === 'ArrowUp' || e.key === 'ArrowLeft') {
+      if (document.activeElement === perspSelect) return;
+      e.preventDefault(); perspStep(-1);
+    }
+  });
+})();
+]]></script>
+</svg>`;
+
+    const blob = new Blob([svgContent], { type: "image/svg+xml" });
+    const fileName = `${erdDocument.documentName}.svg`;
     download(fileName, blob);
 };
 

--- a/src/features/canvas/ControlPanel.tsx
+++ b/src/features/canvas/ControlPanel.tsx
@@ -805,20 +805,21 @@ const downloadSvg = (erdDocument: ErdDocument) => {
             const optEl = optStr ? `<text x="${xOff}" y="${textY}" fill="#888" font-size="11" font-family="sans-serif">${escSvg(optStr)}</text>` : "";
 
             if (ci > 0) {
-                rows += `<line x1="0" y1="${cumulY}" x2="${tableW}" y2="${cumulY}" stroke="#e0e0e0" stroke-width="0.5"/>`;
+                rows += `<line x1="1" y1="${cumulY}" x2="${tableW - 1}" y2="${cumulY}" stroke="#e0e0e0" stroke-width="0.5"/>`;
             }
             rows += pkIcon + fkIcon + nameEl + typeEl + optEl;
             cumulY += rh;
         }
 
         svgTables.push(`<g data-model-id="${tvm.tableId}" transform="translate(${x}, ${y})">
-  <rect width="${tableW}" height="${tableH}" rx="${BORDER_RADIUS}" fill="#FDFDFD" stroke="#bbb" stroke-width="1.5"/>
+  <rect width="${tableW}" height="${tableH}" rx="${BORDER_RADIUS}" fill="#FDFDFD"/>
   <clipPath id="clip-hdr-${tvm.tableId}"><rect width="${tableW}" height="${headerH}" rx="${BORDER_RADIUS}"/></clipPath>
   <rect width="${tableW}" height="${headerH}" fill="${bgHex}" clip-path="url(#clip-hdr-${tvm.tableId})"/>
   <rect x="0" y="${headerH - BORDER_RADIUS}" width="${tableW}" height="${BORDER_RADIUS}" fill="${bgHex}"/>
   <text x="${COL_PAD}" y="${headerH * 0.68}" fill="${fgHex}" font-size="${HEADER_FONT}" font-weight="600" font-family="sans-serif">${escSvg(tableName)}</text>
-  <line x1="0" y1="${headerH}" x2="${tableW}" y2="${headerH}" stroke="#999" stroke-width="1"/>
+  <line x1="0" y1="${headerH}" x2="${tableW}" y2="${headerH}" stroke="#000" stroke-width="0.5"/>
   ${rows}
+  <rect width="${tableW}" height="${tableH}" rx="${BORDER_RADIUS}" fill="none" stroke="#000" stroke-width="1.5"/>
 </g>`);
     }
 
@@ -911,36 +912,47 @@ const downloadSvg = (erdDocument: ErdDocument) => {
 
     const svgContent = `<?xml version="1.0" encoding="UTF-8"?>
 <svg xmlns="http://www.w3.org/2000/svg"
-     viewBox="${vbX} ${vbY} ${vbW} ${vbH}" preserveAspectRatio="none" style="background:#f5f5f5;width:100vw;height:100vh;display:block">
+     viewBox="${vbX} ${vbY} ${vbW} ${vbH}" preserveAspectRatio="none" style="background:#fff;width:100vw;height:100vh;display:block">
 <defs>
 ${defsContent}
+<pattern id="grid" width="25" height="25" patternUnits="userSpaceOnUse">
+  <rect width="1.25" height="25" fill="#e8e8e8"/>
+  <rect width="25" height="1.25" fill="#e8e8e8"/>
+</pattern>
 <style>
   .search-highlight rect:first-child { stroke: #ff6b00 !important; stroke-width: 3 !important; }
 </style>
 </defs>
+<rect x="-50000" y="-50000" width="150000" height="150000" fill="url(#grid)"/>
 <g id="erd-content">
   <g id="memo-layer">${svgMemos.join("\n")}</g>
   <g id="connection-layer">${connectionGroups}</g>
   <g id="label-layer">${labelGroups}</g>
   <g id="table-layer">${svgTables.join("\n")}</g>
 </g>
-<g id="ui-overlay">
-  <rect id="toolbar-bg" x="0" y="0" width="714" height="42" fill="#fff" stroke="#ddd" stroke-width="1" rx="6"/>
-  <text id="title-text" x="14" y="27" font-size="16" font-weight="700" fill="#333" font-family="sans-serif">${escSvg(erdDocument.documentName)}</text>
-  <text x="250" y="27" font-size="14" fill="#444" font-weight="600" font-family="sans-serif">Perspective:</text>
-  <foreignObject x="338" y="6" width="220" height="32">
-    <div xmlns="http://www.w3.org/1999/xhtml">
-      <select id="persp-select" style="width:210px;height:28px;font-size:14px;border:1px solid #ccc;border-radius:4px;padding:2px 6px;background:#fff;color:#333;font-family:sans-serif">
-        <option value="all" selected="selected">All</option>
-        ${perspOptions}
-      </select>
-    </div>
-  </foreignObject>
-  <g id="zoom-out-btn" cursor="pointer"><rect x="570" y="7" width="28" height="28" fill="#fff" stroke="#ccc" rx="4"/><text x="579" y="27" font-size="18" fill="#333" font-family="sans-serif">\u2212</text></g>
-  <text id="zoom-display" x="604" y="27" font-size="14" fill="#333" font-family="sans-serif">100%</text>
-  <g id="zoom-in-btn" cursor="pointer"><rect width="28" height="28" fill="#fff" stroke="#ccc" rx="4"/><text x="8" y="20" font-size="18" fill="#333" font-family="sans-serif">+</text></g>
-  <g id="zoom-fit-btn" cursor="pointer"><rect width="34" height="28" fill="#fff" stroke="#ccc" rx="4"/><text x="7" y="20" font-size="14" fill="#333" font-family="sans-serif">Fit</text></g>
-</g>
+<foreignObject id="ui-overlay" x="0" y="0" width="100%" height="50">
+  <div xmlns="http://www.w3.org/1999/xhtml" id="toolbar" style="display:flex;align-items:center;gap:12px;padding:8px 16px;background:#fff;border-bottom:1px solid #ddd;font-family:sans-serif;font-size:13px;color:#333;box-sizing:border-box;overflow:hidden">
+    <style>
+      #toolbar button:active { background: #e0e0e0 !important; }
+      #toolbar button:hover { background: #f5f5f5 !important; }
+      #toolbar select:focus, #toolbar input:focus { outline: 1px solid #999; }
+    </style>
+    <span style="font-weight:700;font-size:15px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;min-width:0;flex-shrink:1">${escSvg(erdDocument.documentName)}</span>
+    <span style="font-weight:600;white-space:nowrap;flex-shrink:0">Perspective:</span>
+    <select id="persp-select" style="padding:4px 8px;border-radius:4px;border:1px solid #ccc;font-size:13px;max-width:340px;background:#fff;color:#333;flex-shrink:0">
+      <option value="all" selected="selected">All</option>
+      ${perspOptions}
+    </select>
+    <input id="search-box" type="text" placeholder="Search tables..." style="padding:4px 8px;border-radius:4px;border:1px solid #ccc;font-size:13px;width:180px;background:#fff;color:#333;flex-shrink:1;min-width:80px"/>
+    <span style="flex:1"></span>
+    <span style="display:flex;align-items:center;gap:4px;flex-shrink:0;white-space:nowrap">
+      <button id="zoom-out-btn" style="padding:4px 10px;border:1px solid #ccc;border-radius:4px;background:#fff;cursor:pointer;font-size:13px;color:#333">\u2212</button>
+      <span id="zoom-display" style="min-width:40px;text-align:center">100%</span>
+      <button id="zoom-in-btn" style="padding:4px 10px;border:1px solid #ccc;border-radius:4px;background:#fff;cursor:pointer;font-size:13px;color:#333">+</button>
+      <button id="zoom-fit-btn" style="padding:4px 10px;border:1px solid #ccc;border-radius:4px;background:#fff;cursor:pointer;font-size:13px;color:#333">Fit</button>
+    </span>
+  </div>
+</foreignObject>
 <script type="text/ecmascript"><![CDATA[
 (function() {
   var svg = document.documentElement;
@@ -948,9 +960,6 @@ ${defsContent}
   var overlay = document.getElementById('ui-overlay');
   var perspSelect = document.getElementById('persp-select');
   var zoomDisp = document.getElementById('zoom-display');
-  var zoomInBtn = document.getElementById('zoom-in-btn');
-  var zoomFitBtn = document.getElementById('zoom-fit-btn');
-  var toolbarBg = document.getElementById('toolbar-bg');
   var PERSPECTIVES = ${perspJson};
   var MEMO_TABLES = ${memoTableJson};
 
@@ -962,20 +971,11 @@ ${defsContent}
     var s = {}; p.ids.forEach(function(id) { s[id] = true; }); idSets[p.id] = s;
   });
 
-  function layoutZoomControls() {
-    var bbox = zoomDisp.getBBox();
-    var afterText = bbox.x + bbox.width + 6;
-    zoomInBtn.setAttribute('transform', 'translate(' + afterText + ',7)');
-    var fitX = afterText + 36;
-    zoomFitBtn.setAttribute('transform', 'translate(' + fitX + ',7)');
-    toolbarBg.setAttribute('width', String(fitX + 42));
-  }
-
   function updateViewBox() {
     svg.setAttribute('viewBox', curVbX + ' ' + curVbY + ' ' + curVbW + ' ' + curVbH);
-    var pct = Math.round((vbW / curVbW) * 100);
+    var sw = window.innerWidth || 800;
+    var pct = Math.round((sw / curVbW) * 100);
     zoomDisp.textContent = pct + '%';
-    layoutZoomControls();
     positionOverlay();
   }
 
@@ -998,10 +998,17 @@ ${defsContent}
   function positionOverlay() {
     var sw = window.innerWidth || 800;
     var s = curVbW / sw;
-    var tbW = parseFloat(toolbarBg.getAttribute('width')) || 714;
-    var toolbarW = tbW * s;
-    var offsetX = curVbX + (curVbW - toolbarW) / 2;
-    overlay.setAttribute('transform', 'translate(' + offsetX + ',' + curVbY + ') scale(' + s + ')');
+    var tbScreenH = 50;
+    overlay.setAttribute('x', curVbX);
+    overlay.setAttribute('y', curVbY);
+    overlay.setAttribute('width', curVbW);
+    overlay.setAttribute('height', tbScreenH * s);
+    var tb = document.getElementById('toolbar');
+    if (tb) {
+      tb.style.transform = 'scale(' + s + ')';
+      tb.style.transformOrigin = 'top left';
+      tb.style.width = sw + 'px';
+    }
   }
   window.addEventListener('resize', function() { matchAspect(); updateViewBox(); });
 
@@ -1026,7 +1033,9 @@ ${defsContent}
 
   function fitAll() {
     var bb = visibleBBox();
-    curVbX = bb.x; curVbY = bb.y; curVbW = bb.w; curVbH = bb.h;
+    curVbW = bb.w / 0.95; curVbH = bb.h / 0.95;
+    curVbX = bb.x - (curVbW - bb.w) / 2;
+    curVbY = bb.y - (curVbH - bb.h) / 2;
     matchAspect();
     var tbH = 42 * (curVbW / (window.innerWidth || 800));
     curVbY -= tbH / 2;
@@ -1068,7 +1077,10 @@ ${defsContent}
     var ctm = svg.getScreenCTM().inverse();
     var svgPt = pt.matrixTransform(ctm);
     var factor = e.deltaY > 0 ? 1.1 : 0.9;
-    var newW = curVbW * factor;
+    var sw = window.innerWidth || 800;
+    var minVbW = sw / 50;
+    var newW = Math.max(minVbW, curVbW * factor);
+    factor = newW / curVbW;
     var newH = curVbH * factor;
     curVbX = svgPt.x - (svgPt.x - curVbX) * factor;
     curVbY = svgPt.y - (svgPt.y - curVbY) * factor;
@@ -1077,8 +1089,11 @@ ${defsContent}
   }, {passive: false});
 
   function zoom(factor) {
+    var sw = window.innerWidth || 800;
+    var minVbW = sw / 50;
     var cx = curVbX + curVbW / 2, cy = curVbY + curVbH / 2;
-    curVbW *= factor; curVbH *= factor;
+    curVbW = Math.max(minVbW, curVbW * factor);
+    curVbH = Math.max(minVbW, curVbH * factor);
     curVbX = cx - curVbW / 2; curVbY = cy - curVbH / 2;
     updateViewBox();
   }
@@ -1118,16 +1133,36 @@ ${defsContent}
     applyPerspective(perspSelect.value);
   }
 
+  var searchBox = document.getElementById('search-box');
+  searchBox.addEventListener('input', function() {
+    var q = searchBox.value.toLowerCase().trim();
+    var tables = document.getElementById('table-layer').querySelectorAll('[data-model-id]');
+    for (var i = 0; i < tables.length; i++) {
+      var cls = tables[i].getAttribute('class') || '';
+      tables[i].setAttribute('class', cls.replace(/\\s*search-highlight/g, ''));
+    }
+    if (!q) return;
+    for (var j = 0; j < tables.length; j++) {
+      var hdr = tables[j].querySelector('text');
+      if (hdr && hdr.textContent.toLowerCase().indexOf(q) >= 0) {
+        var c2 = tables[j].getAttribute('class') || '';
+        tables[j].setAttribute('class', c2 + ' search-highlight');
+      }
+    }
+  });
+
   document.addEventListener('keydown', function(e) {
     if (e.key === '0' && (e.metaKey || e.ctrlKey)) { e.preventDefault(); fitAll(); }
     if (e.key === '=' && (e.metaKey || e.ctrlKey)) { e.preventDefault(); zoom(0.8); }
     if (e.key === '-' && (e.metaKey || e.ctrlKey)) { e.preventDefault(); zoom(1.25); }
+    if (e.key === '/' && !e.metaKey && !e.ctrlKey) { e.preventDefault(); searchBox.focus(); }
+    if (e.key === 'Escape') { searchBox.blur(); searchBox.value = ''; searchBox.dispatchEvent(new Event('input')); }
     if (e.key === 'ArrowDown' || e.key === 'ArrowRight') {
-      if (document.activeElement === perspSelect) return;
+      if (document.activeElement === perspSelect || document.activeElement === searchBox) return;
       e.preventDefault(); perspStep(1);
     }
     if (e.key === 'ArrowUp' || e.key === 'ArrowLeft') {
-      if (document.activeElement === perspSelect) return;
+      if (document.activeElement === perspSelect || document.activeElement === searchBox) return;
       e.preventDefault(); perspStep(-1);
     }
   });

--- a/src/features/canvas/ControlPanel.tsx
+++ b/src/features/canvas/ControlPanel.tsx
@@ -29,7 +29,7 @@ import { LocalSettingContext } from "~/context/LocalSettingContext";
 import { ERD_MEMO_VIEW_CLASS_NAME } from "~/features/canvas/StickyMemoView";
 import ExportSpecificationContext, { ImageContent } from "~/context/ExportSpecificationContext";
 import DescriptionTooltip from "~/features/canvas/DescriptionTooltip";
-import { getScroll } from "~/features/canvas/support";
+import { DRAWABLE_AREA, getScroll } from "~/features/canvas/support";
 
 type ControlPanelProps = {
     erdExportable: boolean
@@ -436,6 +436,28 @@ const downloadHtml = (erdDocument: ErdDocument) => {
         ids: p.getContainIds()
     })));
 
+    const { frontMemos: htmlFrontMemos, backMemos: htmlBackMemos } = erdDocument.getMemoViewModels();
+    const htmlAllMemos = [...htmlBackMemos, ...htmlFrontMemos];
+    const htmlTableViewModels = erdDocument.getTableViewModels();
+    const htmlMemoTableMap: Record<string, string[]> = {};
+    for (const memo of htmlAllMemos) {
+        const r = memo.rectangleViewModel;
+        const mx = r.positionX + DRAWABLE_AREA.width / 2;
+        const my = r.positionY + DRAWABLE_AREA.height / 2;
+        const contained = htmlTableViewModels
+            .filter(t => {
+                const tx = t.corner.left + DRAWABLE_AREA.width / 2;
+                const ty = t.corner.top + DRAWABLE_AREA.height / 2;
+                const el = document.getElementById(t.tableId);
+                const tw = el ? el.offsetWidth : 220;
+                const th = el ? el.offsetHeight : 100;
+                return tx >= mx && ty >= my && tx + tw <= mx + r.width && ty + th <= my + r.height;
+            })
+            .map(t => t.tableId);
+        if (contained.length > 0) htmlMemoTableMap[memo.memoId] = contained;
+    }
+    const htmlMemoTableJson = JSON.stringify(htmlMemoTableMap);
+
     const html = `<!DOCTYPE html>
 <html lang="en">
 <head>
@@ -499,6 +521,7 @@ html, body { width: 100%; height: 100%; overflow: hidden; background: #f5f5f5; }
   const cropX = ${cropX}, cropY = ${cropY};
   const contentW = ${contentW}, contentH = ${contentH};
   const PERSPECTIVES = ${perspJson};
+  const MEMO_TABLES = ${htmlMemoTableJson};
 
   PERSPECTIVES.forEach(p => {
     const opt = document.createElement('option');
@@ -518,11 +541,28 @@ html, body { width: 100%; height: 100%; overflow: hidden; background: #f5f5f5; }
     zoomDisplay.textContent = Math.round(scale * 100) + '%';
   }
 
+  function visibleBounds() {
+    const models = wrapper.querySelectorAll('[data-model-id]');
+    let mnX = Infinity, mnY = Infinity, mxX = -Infinity, mxY = -Infinity;
+    models.forEach(el => {
+      if (el.style.opacity === '0') return;
+      const r = el.getBoundingClientRect();
+      const wx = (el.offsetLeft || r.left);
+      const wy = (el.offsetTop || r.top);
+      mnX = Math.min(mnX, wx); mnY = Math.min(mnY, wy);
+      mxX = Math.max(mxX, wx + r.width / scale); mxY = Math.max(mxY, wy + r.height / scale);
+    });
+    if (mnX === Infinity) return { cx: cropX, cy: cropY, cw: contentW, ch: contentH };
+    const pad = 100;
+    return { cx: mnX - pad, cy: mnY - pad, cw: mxX - mnX + pad * 2, ch: mxY - mnY + pad * 2 };
+  }
+
   function fitAll() {
     const vw = viewport.clientWidth, vh = viewport.clientHeight;
-    scale = Math.min(vw / contentW, vh / contentH, 2) * 0.95;
-    panX = (vw - contentW * scale) / 2 - cropX * scale;
-    panY = (vh - contentH * scale) / 2 - cropY * scale;
+    const { cx, cy, cw, ch } = visibleBounds();
+    scale = Math.min(vw / cw, vh / ch, 2) * 0.95;
+    panX = (vw - cw * scale) / 2 - cx * scale;
+    panY = (vh - ch * scale) / 2 - cy * scale;
     applyTransform();
   }
 
@@ -573,7 +613,12 @@ html, body { width: 100%; height: 100%; overflow: hidden; background: #f5f5f5; }
     const ids = pid === 'all' ? null : idSet.get(pid);
     modelWrappers.forEach(el => {
       const mid = el.getAttribute('data-model-id');
-      const show = !ids || ids.has(mid);
+      let show;
+      if (!ids) { show = true; }
+      else if (ids.has(mid)) { show = true; }
+      else if (MEMO_TABLES[mid]) {
+        show = MEMO_TABLES[mid].some(tid => ids.has(tid));
+      } else { show = false; }
       el.style.opacity = show ? '' : '0';
       el.style.pointerEvents = show ? '' : 'none';
     });

--- a/src/features/canvas/ControlPanel.tsx
+++ b/src/features/canvas/ControlPanel.tsx
@@ -588,7 +588,7 @@ html, body { width: 100%; height: 100%; overflow: hidden; background: #f5f5f5; }
     const mx = e.clientX - rect.left, my = e.clientY - rect.top;
     const wx = (mx - panX) / scale, wy = (my - panY) / scale;
     const d = e.deltaY > 0 ? 0.9 : 1.1;
-    scale = Math.max(0.05, Math.min(5, scale * d));
+    scale = Math.max(0.05, Math.min(50, scale * d));
     panX = mx - wx * scale; panY = my - wy * scale;
     applyTransform();
   }, { passive: false });
@@ -597,7 +597,7 @@ html, body { width: 100%; height: 100%; overflow: hidden; background: #f5f5f5; }
     const rect = viewport.getBoundingClientRect();
     const cx = rect.width/2, cy = rect.height/2;
     const wx = (cx-panX)/scale, wy = (cy-panY)/scale;
-    scale = Math.min(5, scale*1.25); panX = cx-wx*scale; panY = cy-wy*scale; applyTransform();
+    scale = Math.min(50, scale*1.25); panX = cx-wx*scale; panY = cy-wy*scale; applyTransform();
   });
   document.getElementById('zoom-out').addEventListener('click', () => {
     const rect = viewport.getBoundingClientRect();

--- a/src/features/canvas/ErdRelationPathView.tsx
+++ b/src/features/canvas/ErdRelationPathView.tsx
@@ -675,7 +675,9 @@ const useStraightLineView = (
         return {
             tableIds: [relationModel.parentTableModelId, relationModel.childTableModelId],
             path: (
-                <g key={`relation-line_${relationView.relationId}`}>
+                <g key={`relation-line_${relationView.relationId}`}
+                    data-parent={relationModel.parentTableModelId}
+                    data-child={relationModel.childTableModelId}>
                     <path d={lineSegment.drawingPath} fill="none"
                         stroke={lineViewModel.color.toRgba()}
                         strokeWidth={lineViewModel.strokeWidth}
@@ -886,7 +888,9 @@ const useOrthogonalLine = (
         return {
             tableIds: [relationModel.parentTableModelId, relationModel.childTableModelId],
             path: (
-                <g key={`relation-line_${relationView.relationId}`}>
+                <g key={`relation-line_${relationView.relationId}`}
+                    data-parent={relationModel.parentTableModelId}
+                    data-child={relationModel.childTableModelId}>
                     <path d={drawingLine} fill="none"
                         stroke={relationView.lineViewModel.color.toRgba()}
                         strokeWidth={relationView.lineViewModel.strokeWidth}

--- a/src/features/canvas/RelationLabelOverlay.tsx
+++ b/src/features/canvas/RelationLabelOverlay.tsx
@@ -361,7 +361,10 @@ const RelationLabelOverlay = ({ labelData, selected }: RelationLabelOverlayProps
                     }} />
                 </>
             )}
-            <div ref={labelRef} style={{
+            <div ref={labelRef}
+                data-parent={relationView.relationModel.parentTableModelId}
+                data-child={relationView.relationModel.childTableModelId}
+                style={{
                 position: "absolute",
                 left: `${left}px`,
                 top: `${top}px`,


### PR DESCRIPTION
## Summary

- Add "Save as interactive SVG" to the Export menu
- Generates a self-contained `.svg` with embedded `<script>` for pan/zoom, perspective filtering, and keyboard navigation
- Tables rendered as pure SVG (`<rect>` + `<text>`), not `<foreignObject>` — DOM-measured widths/heights for pixel accuracy
- Connection paths, cardinality markers, and relation labels copied from rendered DOM
- Memos with correct alignment, colors, and font sizes
- Adaptive toolbar centered at top, scales to real pixel size

Closes #169

## Test plan

- [ ] Open `.erd` file → Export → Save as interactive SVG
- [ ] Open SVG in browser — tables, connections, labels, memos render correctly
- [ ] Pan (drag) and zoom (scroll wheel, +/− buttons, Fit button) work
- [ ] Perspective dropdown filters tables, connections, and labels
- [ ] Arrow keys navigate perspectives (non-cyclic)
- [ ] Keyboard shortcuts: Cmd+0 (fit), Cmd+= (zoom in), Cmd+- (zoom out)
- [ ] Toolbar stays centered and at constant size across zoom levels

🤖 Generated with [Claude Code](https://claude.com/claude-code)