### PR TITLE
Fix drag ghost image issue in Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   Fixed an issue where relation lines extending outside the bounds of tables or memos
   were clipped and not fully rendered in the exported PNG image.
 
+- **Firefox: Unexpected drag ghost image when moving selected tables**:
+
+  Fixed an issue in Firefox where dragging tables after a rubber-band selection caused
+  the browser to display an unexpected ghost image roughly the size of the canvas.
+
 
 ## [0.20260426] - 2026-04-26
 

--- a/src/features/canvas/ErdCanvas.tsx
+++ b/src/features/canvas/ErdCanvas.tsx
@@ -442,7 +442,7 @@ const useCanvasStyle = (drawableArea: CanvasArea, displayScale: number) => {
             width: drawableArea.width, height: drawableArea.height,
             overflow: "hidden", display: "flex", flexDirection: "column", alignItems: "center",
             // overscrollBehavior: "none", scrollbarWidth: "none", msOverflowStyle: "none",
-            backgroundColor: "white", backgroundAttachment: "local",
+            backgroundColor: "white", backgroundAttachment: "local", userSelect: "none",
             transform: `scale(${displayScale})`, transformOrigin: "center center"
         };
 


### PR DESCRIPTION
This pull request addresses a Firefox-specific drag-and-drop issue and improves the canvas interaction experience by preventing unwanted text selection. The most important changes are:

**Bug Fixes:**

* Fixed a Firefox issue where dragging tables after a rubber-band selection would cause the browser to display an unexpected ghost image approximately the size of the canvas. (`CHANGELOG.md`)

**UI/UX Improvements:**

* Added `userSelect: "none"` to the canvas container style in `ErdCanvas.tsx` to prevent accidental text selection during canvas interactions.