### PR TITLE
Add configurable comment style for DDL export

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,6 @@
+# ERD Designer
+
+## Build and Test
+
+- Run all tests: `npm run testrun`
+- Watch mode: `npm run test`

--- a/.github/instructions/testing.instructions.md
+++ b/.github/instructions/testing.instructions.md
@@ -1,0 +1,21 @@
+---
+description: >
+  Use when modifying or creating source files.
+  Covers test file placement, test update requirements, and verifying tests pass.
+applyTo: "src/**/*.ts"
+---
+
+# Testing Requirements
+
+Test files live in `__tests__/` directories adjacent to the source file (e.g. `src/models/__tests__/`).
+
+When modifying a source file:
+1. Add or update tests in the corresponding `__tests__/` directory to cover the change.
+2. If creating a new source file, create a matching test file in the adjacent `__tests__/` directory.
+3. Run `npm run testrun` and confirm all tests pass before considering the task complete.
+
+## Code Conventions
+
+- TypeScript strict mode; React components use `.tsx`, plain logic uses `.ts`
+- CSS Modules (`.module.css`) for component styles
+- No ESLint errors (`eslint.config.js`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.20260523] - 2026-05-23
+
+### Added
+
+- **Comment style options for DDL export**:
+
+  When exporting DDL, you can now choose how comments are generated for tables and columns.
+
+  - **Logical Name** *(default)*: Uses only the logical name as a comment. This matches the previous behavior.
+  - **Logical Name + Description**: Combines the logical name and description into a single comment,
+    joined by a configurable separator string.
+
+  The separator can be freely customized in the export dialog.
+  The Comment Style selector and separator input are enabled only when the "Comments" option is checked.
+
+
+## [0.20260521] - 2026-05-21
+
 ### Added
 
 - **CHECK constraint expression for tables and columns**:

--- a/src/extension/mcpserver/documents.ts
+++ b/src/extension/mcpserver/documents.ts
@@ -598,8 +598,11 @@ const initCallbackForExportDdl = (
             withTable: exportDdlSetting?.withTable ?? exportSetting.withTable,
             withIndex: exportDdlSetting?.withIndex ?? exportSetting.withIndex,
             withForeignKey: exportDdlSetting?.withForeignKey ?? exportSetting.withForeignKey,
+            withSchema: exportDdlSetting?.withSchema ?? exportSetting.withSchema,
             withComment: exportDdlSetting?.withComment ?? exportSetting.withComment,
-            withSchema: exportDdlSetting?.withSchema ?? exportSetting.withSchema
+            // TODO
+            commentStyle: "logical_name",
+            commentSeparator: ""
         });
 
         return {

--- a/src/features/editor/ExportDdlView.tsx
+++ b/src/features/editor/ExportDdlView.tsx
@@ -1,14 +1,14 @@
 import React from "react";
 import {
     Alert, Button, Checkbox, Dialog, DialogActions, DialogContent, DialogTitle, Divider,
-    FormControlLabel, Grid, Paper, Stack, TextField, Typography
+    FormControl, FormControlLabel, Grid, InputLabel, MenuItem, Paper, Select, Stack, TextField, Typography
 } from "@mui/material";
 
 import download from "~/components/file-downloader";
 import ErdDocument from "~/models/ErdDocument";
 import { createDdl } from "~/models/create-ddl";
 import ErdSettingModel from "~/models/ErdSettingModel";
-import ExportDdlSettingModel from "~/models/ExportDdlSettingModel";
+import ExportDdlSettingModel, { DdlCommentStyle } from "~/models/ExportDdlSettingModel";
 import { ErdDocumentsHolder } from "~/context/ErdDocumentsHolderContext";
 import { initHandleEnterKeyDown } from "~/features/editor/support";
 
@@ -27,8 +27,10 @@ const ExportDdlView = ({ documentsHolder, isViewOpen, onClose }: ExportDdlViewPr
     const [withTable, setWithTable] = React.useState<boolean>(exportSetting.withTable);
     const [withIndex, setWithIndex] = React.useState<boolean>(exportSetting.withIndex);
     const [withForeignKey, setWithForeignKey] = React.useState<boolean>(exportSetting.withForeignKey);
-    const [withComment, setWithComment] = React.useState<boolean>(exportSetting.withComment);
     const [withSchema, setWithSchema] = React.useState<boolean>(exportSetting.withSchema);
+    const [withComment, setWithComment] = React.useState<boolean>(exportSetting.withComment);
+    const [commentStyle, setCommentStyle] = React.useState<DdlCommentStyle>(exportSetting.commentStyle);
+    const [commentSeparator, setCommentSeparator] = React.useState<string>(exportSetting.commentSeparator);
 
     const database = erdDocument.getDatabase();
     const invalidMessages = initInvalidMessages(erdDocument);
@@ -39,8 +41,8 @@ const ExportDdlView = ({ documentsHolder, isViewOpen, onClose }: ExportDdlViewPr
         }
 
         const ddlOption = {
-            withTable, withIndex, withForeignKey, withComment,
-            withSchema: withSchema && database.supportsSchema
+            withTable, withIndex, withForeignKey, withSchema: withSchema && database.supportsSchema,
+            withComment, commentStyle, commentSeparator
         };
         const ddlQuery = createDdl(erdDocument, ddlOption);
         const ddlFileName = (fileName.toLowerCase().endsWith(".sql") || fileName.toLowerCase().endsWith(".ddl"))
@@ -50,9 +52,9 @@ const ExportDdlView = ({ documentsHolder, isViewOpen, onClose }: ExportDdlViewPr
         // DDL をローカルにダウンロード
         download(ddlFileName, downloadContent);
 
-        const nextExportSetting = new ExportDdlSettingModel(
-            { fileName, withTable, withIndex, withForeignKey, withComment, withSchema }
-        );
+        const nextExportSetting = new ExportDdlSettingModel({
+            fileName, withTable, withIndex, withForeignKey, withSchema, withComment, commentStyle, commentSeparator
+        });
         // 設定が変更された場合のみ保存する
         if (nextExportSetting.equals(exportSetting) === false) {
             const nextErSetting = erdSetting.update({ exportDdlSetting: nextExportSetting });
@@ -66,39 +68,65 @@ const ExportDdlView = ({ documentsHolder, isViewOpen, onClose }: ExportDdlViewPr
     };
 
     const handleEnterDown = initHandleEnterKeyDown(handleExport);
+    const disabledSeparator = (withComment === false) || (commentStyle === "logical_name");
 
     const optionPanel = (
         <Paper elevation={4} sx={{ p: 2 }}>
-            <Typography variant="subtitle1" gutterBottom>CREATE :</Typography>
-            <Grid container sx={{ justifyContent: "flex-start", alignItems: "center" }}>
-                <Grid size={{ md: 3, sm: 6 }}>
-                    <FormControlLabel label="Tables" control={
-                        <Checkbox checked={withTable === true}
-                            onChange={(event) => setWithTable(event.target.checked)} />} />
-                </Grid>
-                <Grid size={{ md: 3, sm: 6 }}>
-                    <FormControlLabel label="Indexes" control={
-                        <Checkbox checked={withIndex === true}
-                            onChange={(event) => setWithIndex(event.target.checked)} />} />
-                </Grid>
-                <Grid size={{ md: 3, sm: 6 }}>
-                    <FormControlLabel label="Foreign Keys" control={
-                        <Checkbox checked={withForeignKey === true}
-                            onChange={(event) => setWithForeignKey(event.target.checked)} />} />
-                </Grid>
-                <Grid size={{ md: 3, sm: 6 }}>
-                    <FormControlLabel label="Comments" control={
-                        <Checkbox checked={withComment === true}
-                            onChange={(event) => setWithComment(event.target.checked)} />} />
-                </Grid>
-                {(database.supportsSchema) && (
+            <Stack direction="column" spacing={2}>
+                <Typography variant="subtitle1" gutterBottom>CREATE :</Typography>
+                <Grid container sx={{ justifyContent: "flex-start", alignItems: "center" }}>
                     <Grid size={{ md: 3, sm: 6 }}>
-                        <FormControlLabel label="Schemas" control={
-                            <Checkbox checked={withSchema === true}
-                                onChange={(event) => setWithSchema(event.target.checked)} />} />
+                        <FormControlLabel label="Tables" control={
+                            <Checkbox checked={withTable === true}
+                                onChange={(event) => setWithTable(event.target.checked)} />} />
                     </Grid>
-                )}
-            </Grid>
+                    <Grid size={{ md: 3, sm: 6 }}>
+                        <FormControlLabel label="Indexes" control={
+                            <Checkbox checked={withIndex === true}
+                                onChange={(event) => setWithIndex(event.target.checked)} />} />
+                    </Grid>
+                    <Grid size={{ md: 3, sm: 6 }}>
+                        <FormControlLabel label="Foreign Keys" control={
+                            <Checkbox checked={withForeignKey === true}
+                                onChange={(event) => setWithForeignKey(event.target.checked)} />} />
+                    </Grid>
+                    {(database.supportsSchema) && (
+                        <Grid size={{ md: 3, sm: 6 }}>
+                            <FormControlLabel label="Schemas" control={
+                                <Checkbox checked={withSchema === true}
+                                    onChange={(event) => setWithSchema(event.target.checked)} />} />
+                        </Grid>
+                    )}
+                </Grid>
+                <Grid container spacing={1} sx={{ justifyContent: "flex-start", alignItems: "center" }}>
+                    <Grid size={{ xs: 3 }}>
+                        <FormControlLabel label="Comments" control={
+                            <Checkbox checked={withComment === true}
+                                onChange={(event) => setWithComment(event.target.checked)} />} />
+                    </Grid>
+                    <Grid size={{ xs: 4 }}>
+                        <FormControl fullWidth size="small">
+                            <InputLabel id="ddl-comment-style-label">Comment Style</InputLabel>
+                            <Select labelId="ddl-comment-style-label" label="Comment Style"
+                                value={commentStyle} disabled={withComment === false}
+                                onChange={(event) => setCommentStyle(event.target.value as DdlCommentStyle)}>
+                                <MenuItem value="logical_name">Logical Name</MenuItem>
+                                <MenuItem value="with_description">Logical Name + Description</MenuItem>
+                            </Select>
+                        </FormControl>
+                    </Grid>
+                    <Grid size={{ xs: 3 }} sx={{ textAlign: "right", paddingRight: 2 }}>
+                        <Typography variant="body2" color={disabledSeparator ? "textSecondary" : ""}>
+                            Comment separator :
+                        </Typography>
+                    </Grid>
+                    <Grid size={{ xs: 1 }}>
+                        <TextField variant="outlined" size="small" fullWidth multiline rows={1}
+                            disabled={disabledSeparator} value={commentSeparator}
+                            onChange={event => setCommentSeparator(event.target.value)} />
+                    </Grid>
+                </Grid>
+            </Stack>
         </Paper>
     );
 

--- a/src/features/editor/ExportDdlView.tsx
+++ b/src/features/editor/ExportDdlView.tsx
@@ -116,7 +116,7 @@ const ExportDdlView = ({ documentsHolder, isViewOpen, onClose }: ExportDdlViewPr
                         </FormControl>
                     </Grid>
                     <Grid size={{ xs: 3 }} sx={{ textAlign: "right", paddingRight: 2 }}>
-                        <Typography variant="body2" color={disabledSeparator ? "textSecondary" : ""}>
+                        <Typography variant="body2" color={disabledSeparator ? "textSecondary" : "textPrimary"}>
                             Comment separator :
                         </Typography>
                     </Grid>

--- a/src/models/ExportDdlSettingModel.ts
+++ b/src/models/ExportDdlSettingModel.ts
@@ -1,17 +1,17 @@
 import { PropertyNotExistsError } from "~/models/exceptions";
 
+export type DdlCommentStyle = "logical_name" | "with_description";
+
 type ExportDdlSettingModelOptions = {
     fileName: string,
     withTable?: boolean,
     withIndex?: boolean,
     withForeignKey?: boolean,
     withSchema?: boolean,
-    withComment?: boolean
-    commentStyle?: "logical_name" | "with_description"
-    commentSeparator?: string
+    withComment?: boolean,
+    commentStyle?: DdlCommentStyle,
+    commentSeparator?: string,
 };
-
-export type DdlCommentStyle = "logical_name" | "with_description";
 
 export default class ExportDdlSettingModel {
 
@@ -92,7 +92,7 @@ export default class ExportDdlSettingModel {
         const withSchema = ("withSchema" in obj) ? obj.withSchema as boolean : false;
         const withComment = ("withComment" in obj) ? obj.withComment as boolean : true;
         const commentStyle = ("commentStyle" in obj) ? obj.commentStyle as DdlCommentStyle : "logical_name";
-        const commentSeparator = ("commentSeparator" in obj) ? obj.commentSeparator as string : ":";
+        const commentSeparator = ("commentSeparator" in obj) ? obj.commentSeparator as string : " : ";
 
         return new ExportDdlSettingModel({
             fileName: obj.fileName as string,

--- a/src/models/ExportDdlSettingModel.ts
+++ b/src/models/ExportDdlSettingModel.ts
@@ -5,9 +5,13 @@ type ExportDdlSettingModelOptions = {
     withTable?: boolean,
     withIndex?: boolean,
     withForeignKey?: boolean,
-    withComment?: boolean,
-    withSchema?: boolean
+    withSchema?: boolean,
+    withComment?: boolean
+    commentStyle?: "logical_name" | "with_description"
+    commentSeparator?: string
 };
+
+export type DdlCommentStyle = "logical_name" | "with_description";
 
 export default class ExportDdlSettingModel {
 
@@ -15,19 +19,23 @@ export default class ExportDdlSettingModel {
     public readonly withTable: boolean;
     public readonly withIndex: boolean;
     public readonly withForeignKey: boolean;
-    public readonly withComment: boolean;
     public readonly withSchema: boolean;
+    public readonly withComment: boolean;
+    public readonly commentStyle: DdlCommentStyle;
+    public readonly commentSeparator: string;
 
     constructor({
-        fileName, withTable = true, withIndex = true, withForeignKey = true, withComment = true,
-        withSchema = true
+        fileName, withTable = true, withIndex = true, withForeignKey = true, withSchema = true,
+        withComment = true, commentStyle = "logical_name", commentSeparator = " : "
     }: ExportDdlSettingModelOptions) {
         this.fileName = fileName;
         this.withTable = withTable;
         this.withIndex = withIndex;
         this.withForeignKey = withForeignKey;
-        this.withComment = withComment;
         this.withSchema = withSchema;
+        this.withComment = withComment;
+        this.commentStyle = commentStyle;
+        this.commentSeparator = commentSeparator;
     }
 
     public equals(other: ExportDdlSettingModel): boolean {
@@ -44,10 +52,16 @@ export default class ExportDdlSettingModel {
         if (this.withForeignKey !== other.withForeignKey) {
             return false;
         }
+        if (this.withSchema !== other.withSchema) {
+            return false;
+        }
         if (this.withComment !== other.withComment) {
             return false;
         }
-        if (this.withSchema !== other.withSchema) {
+        if (this.commentStyle !== other.commentStyle) {
+            return false;
+        }
+        if (this.commentSeparator !== other.commentSeparator) {
             return false;
         }
 
@@ -60,8 +74,10 @@ export default class ExportDdlSettingModel {
             withTable: this.withTable,
             withIndex: this.withIndex,
             withForeignKey: this.withForeignKey,
+            withSchema: this.withSchema,
             withComment: this.withComment,
-            withSchema: this.withSchema
+            commentStyle: this.commentStyle,
+            commentSeparator: this.commentSeparator
         };
     }
 
@@ -73,12 +89,14 @@ export default class ExportDdlSettingModel {
         const withTable = ("withTable" in obj) ? obj.withTable as boolean : true;
         const withIndex = ("withIndex" in obj) ? obj.withIndex as boolean : true;
         const withForeignKey = ("withForeignKey" in obj) ? obj.withForeignKey as boolean : true;
-        const withComment = ("withComment" in obj) ? obj.withComment as boolean : true;
         const withSchema = ("withSchema" in obj) ? obj.withSchema as boolean : false;
+        const withComment = ("withComment" in obj) ? obj.withComment as boolean : true;
+        const commentStyle = ("commentStyle" in obj) ? obj.commentStyle as DdlCommentStyle : "logical_name";
+        const commentSeparator = ("commentSeparator" in obj) ? obj.commentSeparator as string : ":";
 
         return new ExportDdlSettingModel({
             fileName: obj.fileName as string,
-            withTable, withIndex, withForeignKey, withComment, withSchema
+            withTable, withIndex, withForeignKey, withSchema, withComment, commentStyle, commentSeparator
         });
     }
 }

--- a/src/models/__tests__/ExportDdlSettingModel.test.ts
+++ b/src/models/__tests__/ExportDdlSettingModel.test.ts
@@ -12,6 +12,8 @@ describe('ExportDdlSettingModel', () => {
             expect(model.withForeignKey).toBe(true);
             expect(model.withComment).toBe(true);
             expect(model.withSchema).toBe(true);
+            expect(model.commentStyle).toBe('logical_name');
+            expect(model.commentSeparator).toBe(' : ');
         });
 
         test('should create with all values provided', () => {
@@ -21,7 +23,9 @@ describe('ExportDdlSettingModel', () => {
                 withIndex: false,
                 withForeignKey: false,
                 withComment: false,
-                withSchema: false
+                withSchema: false,
+                commentStyle: 'with_description',
+                commentSeparator: ' - '
             });
 
             expect(model.fileName).toBe('custom.sql');
@@ -30,6 +34,8 @@ describe('ExportDdlSettingModel', () => {
             expect(model.withForeignKey).toBe(false);
             expect(model.withComment).toBe(false);
             expect(model.withSchema).toBe(false);
+            expect(model.commentStyle).toBe('with_description');
+            expect(model.commentSeparator).toBe(' - ');
         });
 
         test('should create with partial values (some true, some false)', () => {
@@ -79,7 +85,9 @@ describe('ExportDdlSettingModel', () => {
                 withIndex: false,
                 withForeignKey: true,
                 withComment: false,
-                withSchema: true
+                withSchema: true,
+                commentStyle: 'logical_name',
+                commentSeparator: ' : '
             });
 
             const setting2 = new ExportDdlSettingModel({
@@ -88,10 +96,26 @@ describe('ExportDdlSettingModel', () => {
                 withIndex: false,
                 withForeignKey: true,
                 withComment: false,
-                withSchema: true
+                withSchema: true,
+                commentStyle: 'logical_name',
+                commentSeparator: ' : '
             });
 
             expect(setting1.equals(setting2)).toBe(true);
+        });
+
+        test('should return false for different commentStyle', () => {
+            const setting1 = new ExportDdlSettingModel({ fileName: 'test.sql', commentStyle: 'logical_name' });
+            const setting2 = new ExportDdlSettingModel({ fileName: 'test.sql', commentStyle: 'with_description' });
+
+            expect(setting1.equals(setting2)).toBe(false);
+        });
+
+        test('should return false for different commentSeparator', () => {
+            const setting1 = new ExportDdlSettingModel({ fileName: 'test.sql', commentSeparator: ' : ' });
+            const setting2 = new ExportDdlSettingModel({ fileName: 'test.sql', commentSeparator: ' - ' });
+
+            expect(setting1.equals(setting2)).toBe(false);
         });
 
         test('should return false for different fileName', () => {
@@ -161,7 +185,9 @@ describe('ExportDdlSettingModel', () => {
                 withIndex: false,
                 withForeignKey: true,
                 withComment: false,
-                withSchema: true
+                withSchema: true,
+                commentStyle: 'logical_name',
+                commentSeparator: ' : '
             });
         });
 
@@ -176,7 +202,30 @@ describe('ExportDdlSettingModel', () => {
                 withIndex: true,
                 withForeignKey: true,
                 withComment: true,
-                withSchema: true
+                withSchema: true,
+                commentStyle: 'logical_name',
+                commentSeparator: ' : '
+            });
+        });
+
+        test('should convert to plain object with custom commentStyle and commentSeparator', () => {
+            const model = new ExportDdlSettingModel({
+                fileName: 'test.sql',
+                commentStyle: 'with_description',
+                commentSeparator: ' - '
+            });
+
+            const json = model.toJSON();
+
+            expect(json).toEqual({
+                fileName: 'test.sql',
+                withTable: true,
+                withIndex: true,
+                withForeignKey: true,
+                withComment: true,
+                withSchema: true,
+                commentStyle: 'with_description',
+                commentSeparator: ' - '
             });
         });
     });
@@ -189,7 +238,9 @@ describe('ExportDdlSettingModel', () => {
                 withIndex: true,
                 withForeignKey: false,
                 withComment: true,
-                withSchema: false
+                withSchema: false,
+                commentStyle: 'with_description' as const,
+                commentSeparator: ' - '
             };
 
             const model = ExportDdlSettingModel.toObject(obj);
@@ -201,6 +252,17 @@ describe('ExportDdlSettingModel', () => {
             expect(model.withForeignKey).toBe(false);
             expect(model.withComment).toBe(true);
             expect(model.withSchema).toBe(false);
+            expect(model.commentStyle).toBe('with_description');
+            expect(model.commentSeparator).toBe(' - ');
+        });
+
+        test('should convert from plain object with default commentStyle and commentSeparator', () => {
+            const obj = { fileName: 'test.sql' };
+
+            const model = ExportDdlSettingModel.toObject(obj);
+
+            expect(model.commentStyle).toBe('logical_name');
+            expect(model.commentSeparator).toBe(':');
         });
 
         test('should convert from plain object with missing optional properties (defaults to true)', () => {
@@ -270,7 +332,9 @@ describe('ExportDdlSettingModel', () => {
                 withIndex: true,
                 withForeignKey: false,
                 withComment: true,
-                withSchema: false
+                withSchema: false,
+                commentStyle: 'with_description',
+                commentSeparator: ' - '
             });
 
             const json = original.toJSON();
@@ -283,6 +347,8 @@ describe('ExportDdlSettingModel', () => {
             expect(deserialized.withForeignKey).toBe(original.withForeignKey);
             expect(deserialized.withComment).toBe(original.withComment);
             expect(deserialized.withSchema).toBe(original.withSchema);
+            expect(deserialized.commentStyle).toBe(original.commentStyle);
+            expect(deserialized.commentSeparator).toBe(original.commentSeparator);
             expect(deserialized.equals(original)).toBe(true);
         });
 

--- a/src/models/__tests__/ExportDdlSettingModel.test.ts
+++ b/src/models/__tests__/ExportDdlSettingModel.test.ts
@@ -262,7 +262,7 @@ describe('ExportDdlSettingModel', () => {
             const model = ExportDdlSettingModel.toObject(obj);
 
             expect(model.commentStyle).toBe('logical_name');
-            expect(model.commentSeparator).toBe(':');
+            expect(model.commentSeparator).toBe(' : ');
         });
 
         test('should convert from plain object with missing optional properties (defaults to true)', () => {

--- a/src/models/create-ddl.ts
+++ b/src/models/create-ddl.ts
@@ -7,14 +7,17 @@ import { overrideColumnName } from "~/models/database/support";
 import TableModel from "~/models/database/TableModel";
 import TableUniqueKeysModel from "~/models/database/TableUniqueKeysModel";
 import ErdDocument from "~/models/ErdDocument";
+import { DdlCommentStyle } from "~/models/ExportDdlSettingModel";
 import TableViewModel from "~/models/TableViewModel";
 
 type DdlOption = {
     withTable: boolean,
     withIndex: boolean,
     withForeignKey: boolean,
+    withSchema: boolean,
     withComment: boolean,
-    withSchema: boolean
+    commentStyle: DdlCommentStyle,
+    commentSeparator: string
 };
 
 export const createDdl = (erdDocument: ErdDocument, option: DdlOption) => {
@@ -39,7 +42,7 @@ type IndexQueryArgs = {
 
 type DatabaseDdlCreatorArgs = {
     tableQueryWithOption: (query: string, tableModel: TableModel, option: DdlOption) => string,
-    columnQueryWithOption?: (query: string, overrideName: OverrideName, option: DdlOption) => string,
+    columnQueryWithOption?: (query: string, columnShare: ColumnShareModel, overrideName: OverrideName, option: DdlOption) => string,
     indexQuery: (args: IndexQueryArgs) => string,
     commentQuery: (erdDocument: ErdDocument, option: DdlOption, escape: (value: string) => string) => string[],
     autoIncrementKeyword: string,
@@ -51,9 +54,13 @@ type DatabaseDdlCreatorArgs = {
 class DatabaseDdlCreator {
 
     private readonly tableQueryWithOption: (query: string, tableModel: TableModel, option: DdlOption) => string;
-    private readonly columnQueryWithOption: (query: string, overrideName: OverrideName, option: DdlOption) => string;
+    private readonly columnQueryWithOption: (
+        query: string, columnShare: ColumnShareModel, overrideName: OverrideName, option: DdlOption
+    ) => string;
     private readonly indexQuery: (args: IndexQueryArgs) => string;
-    private readonly commentQuery: (erdDocument: ErdDocument, option: DdlOption, escape: (value: string) => string) => string[];
+    private readonly commentQuery: (
+        erdDocument: ErdDocument, option: DdlOption, escape: (value: string) => string
+    ) => string[];
     private readonly autoIncrementKeyword: string;
     private readonly reservedWords: Set<string>;
     private readonly escapeString: (value: string) => string;
@@ -97,9 +104,7 @@ class DatabaseDdlCreator {
         }
 
         const schemaModels = erdDocument.schemaConfig.getSchemas();
-        const queries = schemaModels.map(schema => {
-            return `CREATE SCHEMA ${this.escape(schema.schemaName)};`;
-        });
+        const queries = schemaModels.map(schema => `CREATE SCHEMA ${this.escape(schema.schemaName)};`);
 
         return (queries.length > 0) ? ["/* create schemas. */", ...queries, "\n"] : [];
     }
@@ -229,7 +234,7 @@ class DatabaseDdlCreator {
         const checkExpression = this.initColumnCheckExpression(columnShareModel, overrideName);
 
         const query = `${this.escape(overrideName.physicalName)} ` + attributes.join(" ")
-        return this.columnQueryWithOption(query, overrideName, option) + checkExpression;
+        return this.columnQueryWithOption(query, columnShareModel, overrideName, option) + checkExpression;
     }
 
     private initColumnCheckExpression(columnShare: ColumnShareModel, overrideName: { physicalName: string }) {
@@ -543,32 +548,42 @@ const msSqlServerReservedWords = [
 
 // cSpell:enable
 
+const initComment = (physicalName: string, logicalName: string, description: string, option: DdlOption): string => {
+    if (option.withComment === false) {
+        return "";
+    }
+
+    if (option.commentStyle === "logical_name") {
+        return (logicalName !== physicalName) ? logicalName : "";
+    }
+
+    const comment = (description !== "") ? `${logicalName}${option.commentSeparator}${description}` : logicalName;
+    return (comment !== physicalName) ? comment : "";
+};
+
 const tableQuery = (query: string, tableModel: TableModel) => {
     return (tableModel.optionExpression !== "") ? `${query}\n${tableModel.optionExpression}` : query;
 };
 
 const tableQueryForMySql = (query: string, tableModel: TableModel, option: DdlOption) => {
+    const tableComment = initComment(tableModel.physicalName, tableModel.logicalName, tableModel.description, option);
+
     const tableOptions = [
         (tableModel.characterSet !== "") ? `CHARACTER SET ${tableModel.characterSet}` : null,
         (tableModel.collate !== "") ? `COLLATE ${tableModel.collate}` : null,
-        (option.withComment && (tableModel.logicalName !== tableModel.physicalName))
-            ? `COMMENT '${escapeComment(tableModel.logicalName)}'` : null,
+        (tableComment !== "") ? `COMMENT '${escapeComment(tableComment)}'` : null,
         (tableModel.optionExpression !== "") ? `\n${tableModel.optionExpression}` : null
     ].filter(option => (option != null));
 
     return (tableOptions.length === 0) ? query : `${query} ${tableOptions.join(", ")}`;
 };
 
-const columnQueryForMySql = (query: string, overrideName: OverrideName, option: DdlOption) => {
-    if (option.withComment === false) {
-        return query
-    }
+const columnQueryForMySql = (
+    query: string, column: ColumnShareModel, overrideName: OverrideName, option: DdlOption
+) => {
+    const columnComment = initComment(overrideName.physicalName, overrideName.logicalName, column.description, option);
 
-    if (overrideName.physicalName === overrideName.logicalName) {
-        return query;
-    }
-
-    return `${query} COMMENT '${escapeComment(overrideName.logicalName)}'`;
+    return (columnComment !== "") ? `${query} COMMENT '${escapeComment(columnComment)}'` : query;
 };
 
 const commentQueryForPostgres = (
@@ -582,28 +597,16 @@ const commentQueryForPostgres = (
     const queries = tableViewModels.flatMap(tableViewModel => {
         const tableModel: TableModel = tableViewModel.tableModel;
         const schemaModel = erdDocument.findSchema(tableModel.schemaId);
+        const tableName = ((schemaModel != null) ? `${escape(schemaModel.schemaName)}.` : "")
+            + escape(tableModel.physicalName);
 
         const commentQueries = erdDocument.toAllColumnModels(tableModel)
-            .map(columnModel => {
-                const columnShareModel = erdDocument.findColumnShareModel(columnModel.columnShareModelId) as ColumnShareModel;
-                if (columnShareModel.logicalName === columnShareModel.physicalName) {
-                    return null;
-                }
+            .map(columnModel => initColumnCommentQueryForPostgres(columnModel, tableName, erdDocument, option, escape))
+            .filter(comment => (comment != null));
 
-                const tableName = ((schemaModel != null) ? `${escape(schemaModel.schemaName)}.` : "")
-                    + escape(tableModel.physicalName);
-                const overrideName = overrideColumnName(columnModel, columnShareModel);
-                const columnName = escape(overrideName.physicalName);
-
-                return `COMMENT ON COLUMN ${tableName}.${columnName}`
-                    + ` IS '${escapeComment(overrideName.logicalName)}';`;
-            })
-            .filter((comment): comment is string => (comment != null));
-
-        if (tableModel.logicalName !== tableModel.physicalName) {
-            const tableName = ((schemaModel != null) ? `${escape(schemaModel.schemaName)}.` : "")
-                + escape(tableModel.physicalName);
-            commentQueries.unshift(`COMMENT ON TABLE ${tableName} IS '${escapeComment(tableModel.logicalName)}';`);
+        const tableComment = initComment(tableModel.physicalName, tableModel.logicalName, tableModel.description, option);
+        if (tableComment !== "") {
+            commentQueries.unshift(`COMMENT ON TABLE ${tableName} IS '${escapeComment(tableComment)}';`);
         }
 
         if (commentQueries.length > 0) {
@@ -614,6 +617,22 @@ const commentQueryForPostgres = (
     });
 
     return (queries.length > 0) ? ["/* create comments. */", ...queries, ""] : [];
+};
+
+const initColumnCommentQueryForPostgres = (
+    columnModel: ColumnModel, tableName: string, erdDocument: ErdDocument, option: DdlOption,
+    escape: (value: string) => string
+) => {
+    const columnShare = erdDocument.findColumnShareModel(columnModel.columnShareModelId) as ColumnShareModel;
+    const overrideName = overrideColumnName(columnModel, columnShare);
+    const comment = initComment(overrideName.physicalName, overrideName.logicalName, columnShare.description, option);
+
+    if (comment === "") {
+        return null;
+    }
+
+    const columnName = escape(overrideName.physicalName);
+    return `COMMENT ON COLUMN ${tableName}.${columnName} IS '${escapeComment(comment)}';`;
 };
 
 const escapeComment = (comment: string) => {

--- a/src/models/create-ddl.ts
+++ b/src/models/create-ddl.ts
@@ -636,7 +636,7 @@ const initColumnCommentQueryForPostgres = (
 };
 
 const escapeComment = (comment: string) => {
-    return comment.replace("'", '"');
+    return comment.replaceAll("'", '"');
 };
 
 const exportConfigs: { [key in DatabaseType]: DatabaseDdlCreator } = {

--- a/src/models/database/__tests__/ColumnShareModel.test.ts
+++ b/src/models/database/__tests__/ColumnShareModel.test.ts
@@ -71,6 +71,7 @@ describe('ColumnShareModel', () => {
             expect(model.scale).toBe('');
             expect(model.unsigned).toBe(false);
             expect(model.description).toBe('');
+            expect(model.checkExpression).toBe('');
             expect(model.characterSet(Database.get('mysql'))).toBe('');
             expect(model.collate).toBe('');
             expect(model.optionExpression).toBe('');
@@ -142,6 +143,18 @@ describe('ColumnShareModel', () => {
             expect(model.characterSet(Database.get('mysql'))).toBe('utf8mb4');
             expect(model.collate).toBe('utf8mb4_unicode_ci');
             expect(model.optionExpression).toBe('opt expr');
+        });
+
+        test('should set and trim checkExpression when provided', () => {
+            const model = new ColumnShareModel({
+                columnShareModelId: 'test-id',
+                physicalName: 'test_column',
+                logicalName: 'Test Column',
+                columnType: mockWithoutUnsigned,
+                checkExpression: '  ${col} > 0  '
+            });
+
+            expect(model.checkExpression).toBe('${col} > 0');
         });
     });
 
@@ -366,6 +379,25 @@ describe('ColumnShareModel', () => {
 
             expect(model1.equals(model2)).toBe(false);
         });
+
+        test('should return false for different checkExpression', () => {
+            const model1 = new ColumnShareModel({
+                columnShareModelId: 'test-id',
+                physicalName: 'test_column',
+                logicalName: 'Test Column',
+                columnType: mockWithoutUnsigned,
+                checkExpression: '${col} > 0'
+            });
+            const model2 = new ColumnShareModel({
+                columnShareModelId: 'test-id',
+                physicalName: 'test_column',
+                logicalName: 'Test Column',
+                columnType: mockWithoutUnsigned,
+                checkExpression: '${col} > 1'
+            });
+
+            expect(model1.equals(model2)).toBe(false);
+        });
     });
 
     describe('toJSON', () => {
@@ -419,6 +451,7 @@ describe('ColumnShareModel', () => {
             expect(json).not.toHaveProperty('unsigned');
             expect(json).not.toHaveProperty('isArray');
             expect(json).not.toHaveProperty('description');
+            expect(json).not.toHaveProperty('checkExpression');
             expect(json).not.toHaveProperty('characterSet');
             expect(json).not.toHaveProperty('collate');
             expect(json).not.toHaveProperty('optionExpression');
@@ -462,6 +495,20 @@ describe('ColumnShareModel', () => {
             expect(json.characterSet).toBe('utf8mb4');
             expect(json.collate).toBe('utf8mb4_unicode_ci');
             expect(json.optionExpression).toBe('opt expr');
+        });
+
+        test('should include checkExpression in JSON when set', () => {
+            const model = new ColumnShareModel({
+                columnShareModelId: 'test-id',
+                physicalName: 'test_column',
+                logicalName: 'Test Column',
+                columnType: mockWithoutUnsigned,
+                checkExpression: '${col} > 0'
+            });
+
+            const json = model.toJSON();
+
+            expect(json.checkExpression).toBe('${col} > 0');
         });
     });
 
@@ -523,6 +570,7 @@ describe('ColumnShareModel', () => {
             expect(model.unsigned).toBe(false);
             expect(model.isArray).toBe(false);
             expect(model.description).toBe('');
+            expect(model.checkExpression).toBe('');
             expect(model.characterSet(Database.get('mysql'))).toBe('');
             expect(model.collate).toBe('');
             expect(model.optionExpression).toBe('');

--- a/src/models/database/__tests__/TableModel.test.ts
+++ b/src/models/database/__tests__/TableModel.test.ts
@@ -110,6 +110,18 @@ describe('TableModel', () => {
             expect(model.optionExpression).toBe('OPT EXPR');
         });
 
+        test('should set checkExpression to empty string by default', () => {
+            const model = new TableModel({});
+
+            expect(model.checkExpression).toBe('');
+        });
+
+        test('should set and trim checkExpression when provided', () => {
+            const model = new TableModel({ checkExpression: '  ${col} > 0  ' });
+
+            expect(model.checkExpression).toBe('${col} > 0');
+        });
+
         test('should set schemaId when provided', () => {
             const schemaId = 'test-schema';
             const model = new TableModel({ schemaId });
@@ -423,6 +435,13 @@ describe('TableModel', () => {
             expect(model1.equals(model2)).toBe(false);
         });
 
+        test('should return false for different checkExpression', () => {
+            const model1 = new TableModel({ checkExpression: '${col} > 0' });
+            const model2 = new TableModel({ checkExpression: '${col} > 1' });
+
+            expect(model1.equals(model2)).toBe(false);
+        });
+
         test('should return false for different characterSet', () => {
             const model1 = new TableModel({ characterSet: 'utf8mb4' });
             const model2 = new TableModel({ characterSet: 'utf8' });
@@ -536,6 +555,31 @@ describe('TableModel', () => {
             const json = model.toJSON();
 
             expect(json).not.toHaveProperty('description');
+        });
+
+        test('should omit empty checkExpression from JSON', () => {
+            const model = new TableModel({
+                tableModelId: 'test-id',
+                physicalName: 'test_table',
+                logicalName: 'Test Table'
+            });
+
+            const json = model.toJSON();
+
+            expect(json).not.toHaveProperty('checkExpression');
+        });
+
+        test('should include checkExpression in JSON when set', () => {
+            const model = new TableModel({
+                tableModelId: 'test-id',
+                physicalName: 'test_table',
+                logicalName: 'Test Table',
+                checkExpression: '${col} > 0'
+            });
+
+            const json = model.toJSON();
+
+            expect(json.checkExpression).toBe('${col} > 0');
         });
 
         test('should handle group columns in columnModelIds', () => {
@@ -766,6 +810,115 @@ describe('TableModel', () => {
             expect(model.collate).toBe('utf8mb4_unicode_ci');
             expect(model.definitionExpression).toBe('DEF EXPR');
             expect(model.optionExpression).toBe('OPT EXPR');
+        });
+
+        test('should deserialize checkExpression', () => {
+            const jsonData = {
+                tableModelId: 'test-id',
+                physicalName: 'test_table',
+                logicalName: 'Test Table',
+                columnModelIds: [],
+                checkExpression: '${col} > 0'
+            };
+
+            const model = TableModel.toObject(jsonData);
+
+            expect(model.checkExpression).toBe('${col} > 0');
+        });
+
+        test('should default checkExpression to empty string when missing', () => {
+            const jsonData = {
+                tableModelId: 'test-id',
+                physicalName: 'test_table',
+                logicalName: 'Test Table',
+                columnModelIds: []
+            };
+
+            const model = TableModel.toObject(jsonData);
+
+            expect(model.checkExpression).toBe('');
+        });
+    });
+
+    describe('updateCheckExpression', () => {
+        test('should return same instance when checkExpression is empty', () => {
+            const model = new TableModel({ checkExpression: '' });
+
+            const result = model.updateCheckExpression([
+                { previousName: { physicalName: 'col' }, nextName: { physicalName: 'new_col' } }
+            ]);
+
+            expect(result).toBe(model);
+        });
+
+        test('should return same instance when changingNames is empty', () => {
+            const model = new TableModel({ checkExpression: '${col} > 0' });
+
+            const result = model.updateCheckExpression([]);
+
+            expect(result).toBe(model);
+        });
+
+        test('should return same instance when no placeholder matches', () => {
+            const model = new TableModel({ checkExpression: '${col} > 0' });
+
+            const result = model.updateCheckExpression([
+                { previousName: { physicalName: 'other' }, nextName: { physicalName: 'new_other' } }
+            ]);
+
+            expect(result).toBe(model);
+        });
+
+        test('should replace matching placeholder with new column name', () => {
+            const model = new TableModel({ checkExpression: '${col} > 0' });
+
+            const result = model.updateCheckExpression([
+                { previousName: { physicalName: 'col' }, nextName: { physicalName: 'new_col' } }
+            ]);
+
+            expect(result).not.toBe(model);
+            expect(result.checkExpression).toBe('${new_col} > 0');
+        });
+
+        test('should replace all occurrences of the matching placeholder', () => {
+            const model = new TableModel({ checkExpression: '${col} > 0 AND ${col} < 100' });
+
+            const result = model.updateCheckExpression([
+                { previousName: { physicalName: 'col' }, nextName: { physicalName: 'amount' } }
+            ]);
+
+            expect(result.checkExpression).toBe('${amount} > 0 AND ${amount} < 100');
+        });
+
+        test('should handle multiple column name replacements', () => {
+            const model = new TableModel({ checkExpression: '${a} > 0 AND ${b} < 100' });
+
+            const result = model.updateCheckExpression([
+                { previousName: { physicalName: 'a' }, nextName: { physicalName: 'col_a' } },
+                { previousName: { physicalName: 'b' }, nextName: { physicalName: 'col_b' } }
+            ]);
+
+            expect(result.checkExpression).toBe('${col_a} > 0 AND ${col_b} < 100');
+        });
+
+        test('should preserve other properties after update', () => {
+            const model = new TableModel({
+                tableModelId: 'test-id',
+                physicalName: 'test_table',
+                logicalName: 'Test Table',
+                description: 'desc',
+                checkExpression: '${col} > 0'
+            });
+
+            const result = model.updateCheckExpression([
+                { previousName: { physicalName: 'col' }, nextName: { physicalName: 'new_col' } }
+            ]);
+
+            expect(result.tableModelId).toBe('test-id');
+            expect(result.physicalName).toBe('test_table');
+            expect(result.logicalName).toBe('Test Table');
+            expect(result.description).toBe('desc');
+            expect(result.checkExpression).toBe('${new_col} > 0');
         });
     });
 


### PR DESCRIPTION
This pull request adds new options for customizing how comments are generated when exporting DDL (Data Definition Language) scripts. Users can now select between different comment styles and specify a separator for combining logical names and descriptions. The export dialog UI and the underlying models and DDL generation logic have been updated to support these new features.

**Enhancements to DDL Export Comment Options:**

* Added support for selecting comment style in DDL export: users can choose between "Logical Name" (the previous default) or "Logical Name + Description", with a customizable separator. The UI only enables these options when comments are included. (`src/features/editor/ExportDdlView.tsx`, `CHANGELOG.md`) [[1]](diffhunk://#diff-82061505814a35faa026495ce508a550fa69ad76de177696f40e3db91cbf0cc4L30-R33) [[2]](diffhunk://#diff-82061505814a35faa026495ce508a550fa69ad76de177696f40e3db91cbf0cc4R71-R75) [[3]](diffhunk://#diff-82061505814a35faa026495ce508a550fa69ad76de177696f40e3db91cbf0cc4R101-R129) [[4]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR9-R26)
* Updated the DDL export settings model to store and handle the new comment style and separator options, including serialization, deserialization, and equality checking. (`src/models/ExportDdlSettingModel.ts`) [[1]](diffhunk://#diff-780bfe8662996b0fab3f20911a28fe962df9e4eb9154bc554eec151d654e920fL8-R38) [[2]](diffhunk://#diff-780bfe8662996b0fab3f20911a28fe962df9e4eb9154bc554eec151d654e920fR55-R64) [[3]](diffhunk://#diff-780bfe8662996b0fab3f20911a28fe962df9e4eb9154bc554eec151d654e920fR77-R80) [[4]](diffhunk://#diff-780bfe8662996b0fab3f20911a28fe962df9e4eb9154bc554eec151d654e920fL76-R99)

**Changes to DDL Generation Logic:**

* Modified DDL generation to use the selected comment style and separator for both table and column comments, ensuring the output matches user preferences. (`src/models/create-ddl.ts`) [[1]](diffhunk://#diff-46a53d1a6ae597bd92980bf8b4031675a3f1910556c36e9bcd0172b9d1811672R10-R20) [[2]](diffhunk://#diff-46a53d1a6ae597bd92980bf8b4031675a3f1910556c36e9bcd0172b9d1811672R551-R586) [[3]](diffhunk://#diff-46a53d1a6ae597bd92980bf8b4031675a3f1910556c36e9bcd0172b9d1811672L585-R609)
* Refactored function signatures and logic in DDL generation to support passing and using the new comment options throughout the codebase. (`src/models/create-ddl.ts`) [[1]](diffhunk://#diff-46a53d1a6ae597bd92980bf8b4031675a3f1910556c36e9bcd0172b9d1811672L42-R45) [[2]](diffhunk://#diff-46a53d1a6ae597bd92980bf8b4031675a3f1910556c36e9bcd0172b9d1811672L54-R63) [[3]](diffhunk://#diff-46a53d1a6ae597bd92980bf8b4031675a3f1910556c36e9bcd0172b9d1811672L232-R237) [[4]](diffhunk://#diff-46a53d1a6ae597bd92980bf8b4031675a3f1910556c36e9bcd0172b9d1811672L100-R107)

These changes make DDL exports more flexible and informative by allowing users to control the format and content of generated comments.