### PR TITLE
Fix PNG export functionality in VS Code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.20260707] - 2026-07-07
+
+### Fixed
+
+- **PNG export rendering in the VS Code extension**:
+
+  Exporting a diagram to PNG from the VS Code extension could produce a broken or
+  incomplete image. PNG export now renders correctly.
+
+
 ## [0.20260706] - 2026-07-06
 
 ### Added

--- a/src/features/export/pngExporter.ts
+++ b/src/features/export/pngExporter.ts
@@ -66,8 +66,7 @@ const rasterizeSvgOnClonedCanvas = (
 
     const serializer = new XMLSerializer();
     const svgString = serializer.serializeToString(svgElement);
-    const svgBlob = new Blob([svgString], { type: "image/svg+xml;charset=utf-8" });
-    const svgUrl = URL.createObjectURL(svgBlob);
+    const svgUrl = `data:image/svg+xml,${encodeURIComponent(svgString)}`;
 
     return new Promise<void>(resolve => {
         const svgImage = new Image();
@@ -82,8 +81,6 @@ const rasterizeSvgOnClonedCanvas = (
                 renderingContext.drawImage(svgImage, 0, 0, svgWidth, svgHeight);
             }
 
-            URL.revokeObjectURL(svgUrl);
-
             rasterCanvas.style.position = "absolute";
             rasterCanvas.style.left = `${svgLeft}px`;
             rasterCanvas.style.top = `${svgTop}px`;
@@ -97,7 +94,6 @@ const rasterizeSvgOnClonedCanvas = (
         };
 
         svgImage.onerror = () => {
-            URL.revokeObjectURL(svgUrl);
             resolve();
         };
 


### PR DESCRIPTION
This pull request addresses an issue with PNG export rendering in the VS Code extension, ensuring that diagrams exported as PNG images are now rendered correctly. The main fix involves changing how SVG images are converted for rasterization, which resolves a bug that previously caused broken or incomplete PNG exports.

**Bug Fixes:**

* PNG export rendering in the VS Code extension now works correctly by switching from using a `Blob`/`ObjectURL` to a data URL for the SVG image source. This avoids issues with revoked URLs and ensures the image loads properly. (`src/features/export/pngExporter.ts`)
* Removed unnecessary calls to `URL.revokeObjectURL`, since data URLs do not require manual revocation. (`src/features/export/pngExporter.ts`) [[1]](diffhunk://#diff-c05dcad509f444d5063ed07833886bc55aea56e47d86fda3a995d978fdd3ec69L85-L86) [[2]](diffhunk://#diff-c05dcad509f444d5063ed07833886bc55aea56e47d86fda3a995d978fdd3ec69L100)

**Documentation:**

* Added a changelog entry describing the fix for PNG export rendering in the VS Code extension. (`CHANGELOG.md`)