### PR TITLE
Fix keyboard shortcuts interfering with search panel input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.20260711] - 2026-07-11
+
+### Fixed
+
+- **Keyboard shortcuts interfering with search panel input**:
+
+  Typing in the search panel could trigger canvas keyboard shortcuts (e.g. Delete, arrow keys),
+  making it difficult to edit search text. Canvas shortcuts are now suppressed while a text input field has focus.
+
+
 ## [0.20260707] - 2026-07-07
 
 ### Fixed

--- a/src/components/support.ts
+++ b/src/components/support.ts
@@ -11,3 +11,17 @@ export const inOpenControlPanel = () => {
 
     return (dialogs.length > 0) || (backdrops.length > 0);
 };
+
+/**
+ * テキスト入力可能な要素にフォーカスがあるかを判定する。
+ * canvas 上のショートカットキー操作がテキスト入力を妨げないように制御するために使用する。
+ */
+export const isTextInputFocused = (): boolean => {
+    const activeElement = window.document.activeElement;
+    if (activeElement == null) {
+        return false;
+    }
+
+    const tagName = activeElement.tagName;
+    return (tagName === "INPUT") || (tagName === "TEXTAREA");
+};

--- a/src/features/canvas/CanvasSearchPanel.tsx
+++ b/src/features/canvas/CanvasSearchPanel.tsx
@@ -39,8 +39,6 @@ const CanvasSearchPanel = () => {
     }
 
     const handleKeyDown = (event: React.KeyboardEvent) => {
-        event.nativeEvent.stopImmediatePropagation();
-
         if (event.key === "Escape") {
             event.preventDefault();
             searchAction.closeSearch();

--- a/src/features/canvas/ErdCanvas/event-handlers.ts
+++ b/src/features/canvas/ErdCanvas/event-handlers.ts
@@ -4,7 +4,7 @@ import { ErdDocumentsHolder } from "~/context/ErdDocumentsHolderContext";
 import { RELEASE_ACTION, SelectAction } from "~/context/SelectEntityContext";
 import EditMode, { EditModeType } from "~/models/EditMode";
 import { SelectState } from "~/models/SelectState";
-import { inOpenControlPanel } from "~/components/support";
+import { inOpenControlPanel, isTextInputFocused } from "~/components/support";
 
 /**
  * ErdCanvas 内部専用モジュール。外部からの import は禁止 (ESLint no-restricted-imports で検査)。
@@ -63,6 +63,11 @@ export const initEffectOfKeyDownOnCanvas = (handlers: KeyEventHandler[]) => {
         // ダイアログが表示されているときはキー操作を無視する
         const inOpenControlPane = inOpenControlPanel();
         if (inOpenControlPane) {
+            return;
+        }
+
+        // テキスト入力中はキャンバスのショートカットキー操作を無視する
+        if (isTextInputFocused()) {
             return;
         }
 


### PR DESCRIPTION
## Summary
- Canvas keyboard shortcuts (e.g. Delete, arrow keys) were firing while typing in the search panel, since `event.nativeEvent.stopImmediatePropagation()` in `CanvasSearchPanel` was not enough to prevent them.
- Added `isTextInputFocused()` in `src/components/support.ts` and used it in `ErdCanvas`'s key-down handler to skip canvas shortcuts whenever an `INPUT`/`TEXTAREA` element has focus.
- Removed the now-unnecessary `stopImmediatePropagation()` call in `CanvasSearchPanel`.