### PR TITLE
Renew the Google Drive access token without manual re-authorization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **Google Drive app: no more hourly re-authorization by hand**:
+
+  The access token is now renewed silently. Once the token is within ten minutes of expiring, the next
+  click or key press you make in the editor renews it in the background, so a long design session no
+  longer needs you to press "Reauthorize" every hour. Renewal is skipped while you are typing in a text
+  field, so no keystrokes are lost. If the browser blocks the renewal popup, or you have been idle long
+  enough for the token to lapse, the "Reauthorize" notice still appears as before.
+
+### Fixed
+
+- **Google Drive app: edits are no longer discarded when the session expires**:
+
+  An expired access token used to unmount the editor, losing unsaved changes and the undo history.
+  The diagram now stays open and editable; saving and remote sync pause, and the edits made while the
+  session was expired are saved once you re-authorize. If the file changed on Drive in the meantime,
+  the existing conflict notice appears instead of overwriting it.
+
 
 ## [0.20260803] - 2026-08-03
 

--- a/src/features/GoogleDriveApplication.tsx
+++ b/src/features/GoogleDriveApplication.tsx
@@ -1,11 +1,11 @@
-import React from "react";
 import { Route, Routes, useNavigate } from "react-router-dom";
-import { GoogleOAuthProvider, hasGrantedAllScopesGoogle, useGoogleLogin } from "@react-oauth/google";
+import { GoogleOAuthProvider } from "@react-oauth/google";
 
 import GoogleDriveInitializer from "~/features/gdrive/GoogleDriveInitializer";
 import ErdDocument from "~/models/ErdDocument";
 import GoogleDriveFile from "~/features/gdrive/GoogleDriveFile";
 import oauth2Setting from "~/config/OauthSetting";
+import { useGdriveAuthorization } from "~/features/gdrive/gdrive-authorization";
 
 const GoogleDriveApplication = () => {
     const oauthSetting = oauth2Setting();
@@ -18,31 +18,8 @@ const GoogleDriveApplication = () => {
 };
 
 const GoogleDriveInnerApplication = () => {
-    const [implicitToken, setImplicitToken] = React.useState<ImplicitToken>(EMPTY_IMPLICIT_TOKEN);
+    const authorization = useGdriveAuthorization();
     const navigate = useNavigate();
-
-    const authorize = useGoogleLogin({
-        flow: "implicit",
-        scope: GDRIVE_SCOPES.join(" "),
-        onSuccess: response => {
-            console.debug(`Succeed to authorize.`);
-            const hasAccess = hasGrantedAllScopesGoogle(
-                response, "https://www.googleapis.com/auth/drive.file");
-            if (hasAccess === false) {
-                console.warn("Not granted the drive.file scope.");
-                return;
-            }
-
-            const expiresAt = new Date().getTime() + (response.expires_in - 60) * 1000;
-            setImplicitToken({ accessToken: response.access_token, expiresAt });
-        },
-        onNonOAuthError: error => {
-            console.warn(`Canceled to authorize. ${error}`);
-        },
-        onError: error => {
-            console.warn(`Failed to authorize. ${error}`);
-        }
-    });
 
     const handleInitialize = (gdriveFile: GdriveFile) => {
         sessionStorage.setItem("gdriveFileId", gdriveFile.fileId);
@@ -61,30 +38,15 @@ const GoogleDriveInnerApplication = () => {
         <Routes>
             <Route path='init' element={
                 <GoogleDriveInitializer
-                    implicitToken={implicitToken}
-                    authorize={authorize}
+                    authorization={authorization}
                     onInitialize={handleInitialize} />
             } />
             <Route path='' element={
-                <GoogleDriveFile
-                    implicitToken={implicitToken}
-                    authorize={authorize} />
+                <GoogleDriveFile authorization={authorization} />
             } />
         </Routes>
     );
 };
-
-const GDRIVE_SCOPES = [
-    "https://www.googleapis.com/auth/drive.file",
-    "https://www.googleapis.com/auth/drive.install"
-];
-
-type ImplicitToken = {
-    accessToken: string,
-    expiresAt: number
-};
-
-const EMPTY_IMPLICIT_TOKEN: ImplicitToken = { accessToken: "", expiresAt: 0 };
 
 type GdriveFile = {
     fileId: string,

--- a/src/features/gdrive/GoogleDriveFile.tsx
+++ b/src/features/gdrive/GoogleDriveFile.tsx
@@ -13,6 +13,7 @@ import GoogleDriveNoticeLayout from "~/features/gdrive/GoogleDriveNoticeLayout";
 import exportSpreadSheetFormatSpecification from "~/features/spec/GoogleSpreadSheetFormatSpecification";
 import { containedButtonStyle, descriptionStyle } from "~/features/start_up/start-up-styles";
 import { EXTERNAL_DOCUMENT_CHANGED_EVENT, REMOTE_SYNC_REQUESTED_EVENT } from "~/components/constant";
+import { GdriveAuthorization } from "~/features/gdrive/gdrive-authorization";
 
 type SessionDocument = {
     erdDocument: ErdDocument,
@@ -24,16 +25,16 @@ type SessionDocument = {
 type RemoteSyncState = "idle" | "syncing" | "unauthorized";
 
 type GoogleDriveFileProp = {
-    implicitToken: { accessToken: string, expiresAt: number },
-    authorize: () => void
+    authorization: GdriveAuthorization
 };
 
-const GoogleDriveFile = ({ implicitToken, authorize }: GoogleDriveFileProp) => {
+const GoogleDriveFile = ({ authorization }: GoogleDriveFileProp) => {
     const [sessionDocument, setSessionDocument] = React.useState<SessionDocument | null>(initSessionDocument);
     const [messageToast, setMessageToast] = React.useState<MessageToast | null>(null);
     const updateQueueRef = React.useRef<Promise<string>>(Promise.resolve(""));
     const latestDocumentRef = React.useRef<ErdDocument | null>(null);
     const importedDocumentRef = React.useRef<ErdDocument | null>(null);
+    const pendingDocumentRef = React.useRef<ErdDocument | null>(null);
     const syncStateRef = React.useRef<RemoteSyncState>("idle");
 
     const gdriveFileId = sessionStorage.getItem("gdriveFileId");
@@ -56,9 +57,15 @@ const GoogleDriveFile = ({ implicitToken, authorize }: GoogleDriveFileProp) => {
             return;
         }
 
+        // 期限切れ中は Drive へ書き込めないため保留する。再認可後にまとめて 1 件だけ保存する。
+        if (authorization.state !== "authorized") {
+            pendingDocumentRef.current = erdDocument;
+            return;
+        }
+
         const updateFunction = async (currentVersion: string) => {
             const updateArgs = {
-                accessToken: implicitToken.accessToken, fileId: gdriveFileId,
+                accessToken: authorization.accessToken, fileId: gdriveFileId,
                 currentVersion, nextDocument: erdDocument, loggingMessage: message,
                 setMessageToast, setSessionDocument
             };
@@ -66,12 +73,12 @@ const GoogleDriveFile = ({ implicitToken, authorize }: GoogleDriveFileProp) => {
         };
 
         enqueueUpdateTask(updateFunction, "save document");
-    }, [sessionDocument, gdriveFileId, implicitToken, enqueueUpdateTask]);
+    }, [sessionDocument, gdriveFileId, authorization, enqueueUpdateTask]);
 
     const exportSpecification = React.useCallback((erdDocument: ErdDocument) => {
         const specInfo = exportSpreadSheetFormatSpecification(erdDocument);
 
-        createSpreadSheet(implicitToken.accessToken, specInfo).then(spreadSheetId => {
+        createSpreadSheet(authorization.accessToken, specInfo).then(spreadSheetId => {
             const handleOpenSpec = (event: React.MouseEvent) => {
                 event.stopPropagation();
 
@@ -100,7 +107,7 @@ const GoogleDriveFile = ({ implicitToken, authorize }: GoogleDriveFileProp) => {
             };
             setMessageToast(failedToast);
         });
-    }, [implicitToken.accessToken]);
+    }, [authorization.accessToken]);
 
     // 再読み込みされた場合の制御
     React.useEffect(() => {
@@ -109,42 +116,69 @@ const GoogleDriveFile = ({ implicitToken, authorize }: GoogleDriveFileProp) => {
         }
 
         // 再読み込みされた直後は token がクリアされるので、再度認証を行ったうえで最新のファイルを取得する。
-        if (implicitToken.expiresAt < new Date().getTime()) {
+        if (authorization.state !== "authorized") {
             return;
         }
 
         openGdriveFile({
-            accessToken: implicitToken.accessToken, fileId: gdriveFileId
+            accessToken: authorization.accessToken, fileId: gdriveFileId
         }).then(gdriveFile => {
             setSessionDocument({ erdDocument: gdriveFile.erdDocument, version: gdriveFile.version });
         }).catch(error => {
             console.error(`Failed to open file. ${error}`);
         });
-    }, [implicitToken, sessionDocument, gdriveFileId]);
+    }, [authorization, sessionDocument, gdriveFileId]);
 
-    // アクセストークンの有効期限が切れる少し前に通知を表示する
+    // 期限が近づいたら再認可を促す。無音更新に成功すると expiresAt が延びて effect が張り直されるため、
+    // 通知は自分で消える。失効しても編集は続けられるので、その間は通知を出したままにする。
     React.useEffect(() => {
-        const currentDate = new Date().getTime();
-        const remainedTime = implicitToken.expiresAt - currentDate;
-        if (remainedTime <= 0) {
-            setSessionDocument(null);
+        if (authorization.state === "unauthorized") {
             return;
         }
 
-        const notifyTimerId = setTimeout(() => {
-            setMessageToast(initReauthorizeToast(setMessageToast, authorize));
-        }, remainedTime - 3 * 60 * 1000);
+        if (authorization.state === "expired") {
+            const expiredToast = initReauthorizeToast(
+                setMessageToast, authorization.authorize, EXPIRED_MESSAGE);
+            setMessageToast(expiredToast);
+            return;
+        }
 
-        const timeoutTimerId = setTimeout(() => {
-            setMessageToast(null);
-            setSessionDocument(null);
-        }, remainedTime);
+        setMessageToast(current => {
+            return (current?.kind === "reauthorize") ? null : current;
+        });
+
+        const remainedTime = authorization.expiresAt - new Date().getTime();
+        const notifyTimerId = setTimeout(() => {
+            const expiringToast = initReauthorizeToast(
+                setMessageToast, authorization.authorize, EXPIRING_MESSAGE);
+            setMessageToast(expiringToast);
+        }, remainedTime - NOTIFY_LEAD_MILLS);
 
         return () => {
-            clearTimeout(timeoutTimerId);
             clearTimeout(notifyTimerId);
         };
-    }, [implicitToken, authorize]);
+    }, [authorization]);
+
+    // 期限切れ中に保留した編集を、再認可できた時点で保存する。
+    // Drive 側が更新されていれば doUpdateDocument の version 比較が競合を検知するため、上書きにはならない。
+    React.useEffect(() => {
+        if (authorization.state !== "authorized") {
+            return;
+        }
+
+        const pendingDocument = pendingDocumentRef.current;
+        if ((pendingDocument == null) || (gdriveFileId == null)) {
+            return;
+        }
+
+        pendingDocumentRef.current = null;
+
+        const savePendingTask = initSavePendingTask({
+            accessToken: authorization.accessToken, fileId: gdriveFileId,
+            nextDocument: pendingDocument, setMessageToast, setSessionDocument
+        });
+        enqueueUpdateTask(savePendingTask, "save pending document");
+    }, [authorization, gdriveFileId, enqueueUpdateTask]);
 
     // ドキュメント読み込み直後に、現在のバージョンを保持する
     React.useEffect(() => {
@@ -174,9 +208,9 @@ const GoogleDriveFile = ({ implicitToken, authorize }: GoogleDriveFileProp) => {
         syncStateRef.current = "idle";
 
         const handleSyncRequest = initHandleSyncRemoteRequest({
-            implicitToken, fileId: gdriveFileId,
+            authorization, fileId: gdriveFileId,
             latestDocumentRef, importedDocumentRef, syncStateRef,
-            enqueueUpdateTask, setMessageToast, authorize
+            enqueueUpdateTask, setMessageToast
         });
 
         window.addEventListener(REMOTE_SYNC_REQUESTED_EVENT, handleSyncRequest);
@@ -184,7 +218,7 @@ const GoogleDriveFile = ({ implicitToken, authorize }: GoogleDriveFileProp) => {
         return () => {
             window.removeEventListener(REMOTE_SYNC_REQUESTED_EVENT, handleSyncRequest);
         };
-    }, [sessionDocument, gdriveFileId, implicitToken, authorize, enqueueUpdateTask]);
+    }, [sessionDocument, gdriveFileId, authorization, enqueueUpdateTask]);
 
     // 初回描画後に、リダイレクト時にドキュメント情報を保持していたセッションを破棄する
     React.useEffect(() => {
@@ -204,21 +238,18 @@ const GoogleDriveFile = ({ implicitToken, authorize }: GoogleDriveFileProp) => {
     }
 
     if (sessionDocument == null) {
-        const currentDate = new Date().getTime();
-
         return (
             <GoogleDriveNoticeLayout>
-                {(implicitToken.expiresAt < currentDate) ? (
+                {(authorization.state === "authorized") ? (<CircularProgress />) : (
                     <Stack spacing={3} sx={{ justifyContent: "center", alignItems: "center", margin: 3 }}>
                         <Typography variant="body1" sx={descriptionStyle}>
                             Need to re-authorize to edit the ERD file on the Google Drive.
                         </Typography>
-                        <Button variant="contained" size="large" sx={containedButtonStyle} onClick={authorize}>
+                        <Button variant="contained" size="large" sx={containedButtonStyle}
+                            onClick={authorization.authorize}>
                             Authorize with Google
                         </Button>
                     </Stack>
-                ) : (
-                    <CircularProgress />
                 )}
             </GoogleDriveNoticeLayout>
         );
@@ -279,7 +310,9 @@ type MessageToast = {
     severity: "info" | "success" | "warning" | "error",
     message: string,
     action: React.ReactNode,
-    autoHideMills?: number
+    autoHideMills?: number,
+    // 再認可を促す通知だけは無音更新の成功時に取り下げる必要があるため、他の通知と区別できるようにする。
+    kind?: "reauthorize"
 };
 
 type DoUpdateDocumentArgs = {
@@ -358,9 +391,22 @@ const initSafeUpdateTask = (task: UpdateTask, taskName: string): UpdateTask => {
     };
 };
 
+// 無音更新はユーザ操作に便乗するため、放置されている間は走らない。
+// 手動の Reauthorize へ切り替えられる猶予として、失効前に通知を出す。
+const NOTIFY_LEAD_MILLS = 3 * 60 * 1000;
+
+const EXPIRING_MESSAGE = "Your session is about to expire in less than a few minutes.\n"
+    + "Please reauthorize your Google account\n"
+    + "to continue using the service without interruption.";
+
+const EXPIRED_MESSAGE = "Your session has expired.\n"
+    + "Your edits are kept in this tab but are no longer saved to Google Drive.\n"
+    + "Please reauthorize your Google account to resume saving.";
+
 const initReauthorizeToast = (
     setMessageToast: React.Dispatch<React.SetStateAction<MessageToast | null>>,
-    authorize: () => void
+    authorize: () => void,
+    message: string
 ): MessageToast => {
     const handleRenewToken = (event: React.MouseEvent) => {
         event.stopPropagation();
@@ -371,22 +417,28 @@ const initReauthorizeToast = (
 
     return {
         severity: "warning",
-        message: "Your session is about to expire in less than a few minutes.\n"
-            + "Please reauthorize your Google account\n"
-            + "to continue using the service without interruption.",
-        action: (<Button color="inherit" size="small" onClick={handleRenewToken}>Reauthorize</Button>)
+        message,
+        action: (<Button color="inherit" size="small" onClick={handleRenewToken}>Reauthorize</Button>),
+        kind: "reauthorize"
+    };
+};
+
+const initSavePendingTask = (
+    args: Omit<DoUpdateDocumentArgs, "currentVersion" | "loggingMessage">
+): UpdateTask => {
+    return async (currentVersion: string) => {
+        return doUpdateDocument({ ...args, currentVersion, loggingMessage: "save pending document" });
     };
 };
 
 type HandleSyncRemoteRequestArgs = {
-    implicitToken: { accessToken: string, expiresAt: number },
+    authorization: GdriveAuthorization,
     fileId: string,
     latestDocumentRef: React.RefObject<ErdDocument | null>,
     importedDocumentRef: React.RefObject<ErdDocument | null>,
     syncStateRef: React.RefObject<RemoteSyncState>,
     enqueueUpdateTask: (task: UpdateTask, taskName: string) => void,
-    setMessageToast: React.Dispatch<React.SetStateAction<MessageToast | null>>,
-    authorize: () => void
+    setMessageToast: React.Dispatch<React.SetStateAction<MessageToast | null>>
 };
 
 const initHandleSyncRemoteRequest = (args: HandleSyncRemoteRequestArgs) => {
@@ -399,7 +451,7 @@ const initHandleSyncRemoteRequest = (args: HandleSyncRemoteRequestArgs) => {
             return;
         }
 
-        if (args.implicitToken.expiresAt < Date.now()) {
+        if (args.authorization.state !== "authorized") {
             return;
         }
 
@@ -414,7 +466,7 @@ const initRemoteSyncTask = (args: HandleSyncRemoteRequestArgs): UpdateTask => {
     return async (currentVersion: string) => {
         try {
             const nextVersion = await doImportRemoteUpdate({
-                accessToken: args.implicitToken.accessToken,
+                accessToken: args.authorization.accessToken,
                 fileId: args.fileId,
                 currentVersion,
                 latestDocumentRef: args.latestDocumentRef,
@@ -430,7 +482,9 @@ const initRemoteSyncTask = (args: HandleSyncRemoteRequestArgs): UpdateTask => {
             args.syncStateRef.current = nextState;
 
             if (nextState === "unauthorized") {
-                args.setMessageToast(initReauthorizeToast(args.setMessageToast, args.authorize));
+                const expiredToast = initReauthorizeToast(
+                    args.setMessageToast, args.authorization.authorize, EXPIRED_MESSAGE);
+                args.setMessageToast(expiredToast);
             } else {
                 console.warn(`Failed to sync remote updated. ${error}`);
             }

--- a/src/features/gdrive/GoogleDriveInitializer.tsx
+++ b/src/features/gdrive/GoogleDriveInitializer.tsx
@@ -7,21 +7,21 @@ import InitializeDatabaseDialog from "~/features/start_up/InitializeDatabaseDial
 import { createGdriveFile, openGdriveFile } from "~/features/gdrive/gdrive-file-support";
 import GoogleDriveNoticeLayout from "~/features/gdrive/GoogleDriveNoticeLayout";
 import { containedButtonStyle, descriptionStyle } from "~/features/start_up/start-up-styles";
+import { GdriveAuthorization } from "~/features/gdrive/gdrive-authorization";
 
 type GoogleDriveInitializerProp = {
-    implicitToken: { accessToken: string, expiresAt: number },
-    authorize: () => void,
+    authorization: GdriveAuthorization,
     onInitialize: (gdriveFile: GdriveFile) => void
 };
 
-const GoogleDriveInitializer = ({ implicitToken, authorize, onInitialize }: GoogleDriveInitializerProp) => {
+const GoogleDriveInitializer = ({ authorization, onInitialize }: GoogleDriveInitializerProp) => {
     const [gdriveFolderId, setGdriveFolderId] = React.useState<string | null>(null);
     const [erdDocument, setErdDocument] = React.useState<ErdDocument | null>(null);
 
     const gdriveState = useGdriveStateParam();
 
     const handleCreateDocument = (erdDocument: ErdDocument) => {
-        if ((gdriveFolderId == null) || (implicitToken.accessToken === "")) {
+        if ((gdriveFolderId == null) || (authorization.state !== "authorized")) {
             return;
         }
 
@@ -29,14 +29,13 @@ const GoogleDriveInitializer = ({ implicitToken, authorize, onInitialize }: Goog
     };
 
     React.useEffect(() => {
-        const currentDate = new Date().getTime();
-        if (implicitToken.expiresAt < currentDate) {
+        if (authorization.state !== "authorized") {
             return;
         }
 
         if (gdriveState.action === "open") {
             openGdriveFile({
-                accessToken: implicitToken.accessToken, fileId: gdriveState.fileId
+                accessToken: authorization.accessToken, fileId: gdriveState.fileId
             }).then(gdriveFile => {
                 onInitialize(gdriveFile);
             }).catch(error => {
@@ -47,7 +46,7 @@ const GoogleDriveInitializer = ({ implicitToken, authorize, onInitialize }: Goog
         if (gdriveState.action === "create") {
             setGdriveFolderId(gdriveState.folderId);
         }
-    }, [implicitToken, gdriveState, authorize, onInitialize]);
+    }, [authorization, gdriveState, onInitialize]);
 
     // GoogleDrive にファイルを新規作成する
     React.useEffect(() => {
@@ -56,26 +55,26 @@ const GoogleDriveInitializer = ({ implicitToken, authorize, onInitialize }: Goog
         }
 
         createGdriveFile({
-            accessToken: implicitToken.accessToken, folderId: gdriveFolderId, erdDocument
+            accessToken: authorization.accessToken, folderId: gdriveFolderId, erdDocument
         }).then(gdriveFile => {
             onInitialize(gdriveFile);
         }).catch(error => {
             console.error(`Failed to create file. ${error}`);
         });
-    }, [erdDocument, gdriveFolderId, implicitToken.accessToken, onInitialize]);
+    }, [erdDocument, gdriveFolderId, authorization.accessToken, onInitialize]);
 
-    const currentDate = new Date().getTime();
     const onProcessing = (erdDocument != null)
-        || ((implicitToken.expiresAt >= currentDate) && (gdriveState.action === "open"));
+        || ((authorization.state === "authorized") && (gdriveState.action === "open"));
 
     return (
         <GoogleDriveNoticeLayout>
-            {(implicitToken.expiresAt < currentDate) && (
+            {(authorization.state !== "authorized") && (
                 <Stack spacing={3} sx={{ justifyContent: "center", alignItems: "center", margin: 3 }}>
                     <Typography variant="body1" sx={descriptionStyle}>
                         Need to authorize to edit the ERD file on the Google Drive.
                     </Typography>
-                    <Button variant="contained" size="large" onClick={authorize} sx={containedButtonStyle}>
+                    <Button variant="contained" size="large"
+                        onClick={authorization.authorize} sx={containedButtonStyle}>
                         Authorize with Google
                     </Button>
                 </Stack>

--- a/src/features/gdrive/__tests__/gdrive-authorization.test.ts
+++ b/src/features/gdrive/__tests__/gdrive-authorization.test.ts
@@ -1,0 +1,39 @@
+import { describe, test, expect } from 'vitest';
+
+import { shouldRenewAccessToken } from '~/features/gdrive/gdrive-authorization';
+
+const CURRENT_TIME = new Date('2026-01-01T00:00:00.000Z').getTime();
+const RENEW_LEAD_MILLS = 10 * 60 * 1000;
+
+describe('shouldRenewAccessToken', () => {
+
+    test('残りが猶予より長い間は更新しない', () => {
+        const expiresAt = CURRENT_TIME + RENEW_LEAD_MILLS + 1;
+
+        expect(shouldRenewAccessToken(expiresAt, CURRENT_TIME)).toBe(false);
+    });
+
+    test('残りが猶予ちょうどになったら更新する', () => {
+        const expiresAt = CURRENT_TIME + RENEW_LEAD_MILLS;
+
+        expect(shouldRenewAccessToken(expiresAt, CURRENT_TIME)).toBe(true);
+    });
+
+    test('残りが猶予を切ったら更新する', () => {
+        const expiresAt = CURRENT_TIME + RENEW_LEAD_MILLS - 1;
+
+        expect(shouldRenewAccessToken(expiresAt, CURRENT_TIME)).toBe(true);
+    });
+
+    // 放置されて失効した後も、次のユーザ操作で復帰できるようにする。
+    test('失効済みでも更新する', () => {
+        const expiresAt = CURRENT_TIME - 1;
+
+        expect(shouldRenewAccessToken(expiresAt, CURRENT_TIME)).toBe(true);
+    });
+
+    // 未認可の初期値 (expiresAt = 0) でも判定は破綻しない。
+    test('未認可の初期値でも更新対象と判定する', () => {
+        expect(shouldRenewAccessToken(0, CURRENT_TIME)).toBe(true);
+    });
+});

--- a/src/features/gdrive/gdrive-authorization.ts
+++ b/src/features/gdrive/gdrive-authorization.ts
@@ -1,0 +1,228 @@
+import React from "react";
+import {
+    hasGrantedAllScopesGoogle, OverridableTokenClientConfig, TokenResponse, useGoogleLogin
+} from "@react-oauth/google";
+
+import { findAuthorizedAccount } from "~/features/gdrive/gdrive-file-support";
+
+// アクセストークンの有効性を表す唯一の状態。
+// expired は「トークンだけが失効し、編集中のドキュメントは生きている」状態で、
+// 一度も認可していない unauthorized とは表示も復帰手順も異なるため区別する。
+export type AuthorizationState = "unauthorized" | "authorized" | "expired";
+
+export type GdriveAuthorization = {
+    state: AuthorizationState,
+    accessToken: string,
+    expiresAt: number,
+    authorize: () => void
+};
+
+/**
+ * Google Drive アクセス用のトークンを保持し、有効期限が近づいたら無音で更新する。
+ *
+ * GIS の requestAccessToken は必ず window.open を同期的に呼ぶため、iframe による無音更新はできず、
+ * ポップアップは transient user activation を要求する。そのためタイマーからは更新できない。
+ * 代わりに期限が近づいた後の最初のユーザ操作に便乗して要求することで、利用者の手作業を不要にする。
+ * 同意済みかつ Google セッションが有効なら prompt: "" によりポップアップは自動で開閉する。
+ */
+export const useGdriveAuthorization = (): GdriveAuthorization => {
+    const [authorization, setAuthorization] = React.useState<AuthorizationToken>(UNAUTHORIZED_TOKEN);
+
+    // 発行済みポップアップ要求の有無。DOM リスナ内で同期的に判定する必要があるため ref で持つ。
+    // AuthorizationState とは対象が異なる (トークンの有効性 vs 未応答の要求) ため別の状態にしている。
+    const renewalStateRef = React.useRef<RenewalState>("idle");
+    const accountEmailRef = React.useRef<string | null>(null);
+
+    const requestToken = useGoogleLogin({
+        flow: "implicit",
+        scope: GDRIVE_SCOPES.join(" "),
+        // ref を render 中に関数へ渡さないよう、コールバックの内部で組み立てる。
+        onSuccess: response => {
+            doAuthorized(response, { setAuthorization, renewalStateRef, accountEmailRef });
+        },
+        onNonOAuthError: error => {
+            console.warn(`Canceled to authorize. ${error.type}`);
+            renewalStateRef.current = "blocked";
+        },
+        onError: error => {
+            console.warn(`Failed to authorize. ${JSON.stringify(error)}`);
+            renewalStateRef.current = "blocked";
+        }
+    });
+
+    // 有効期限に到達したら expired へ落とす。トークン値は保持したままにすることで、
+    // 呼び出し側が編集中のドキュメントを破棄せずに再認可を待てるようにする。
+    React.useEffect(() => {
+        if (authorization.state !== "authorized") {
+            return;
+        }
+
+        const remainedTime = authorization.expiresAt - new Date().getTime();
+        const timerId = setTimeout(() => {
+            setAuthorization(current => {
+                return { state: "expired", accessToken: current.accessToken, expiresAt: current.expiresAt };
+            });
+        }, Math.max(remainedTime, 0));
+
+        return () => {
+            clearTimeout(timerId);
+        };
+    }, [authorization]);
+
+    // 期限切れ後も購読を続ける。放置して失効した場合でも、次のユーザ操作で復帰できるようにする。
+    React.useEffect(() => {
+        if (authorization.state === "unauthorized") {
+            return;
+        }
+
+        const renewToken = initRenewOnUserGesture({
+            expiresAt: authorization.expiresAt, renewalStateRef, accountEmailRef, requestToken
+        });
+
+        window.addEventListener("click", renewToken, { capture: true });
+        window.addEventListener("keyup", renewToken, { capture: true });
+
+        return () => {
+            window.removeEventListener("click", renewToken, { capture: true });
+            window.removeEventListener("keyup", renewToken, { capture: true });
+        };
+    }, [authorization, requestToken]);
+
+    // React の onClick へ直接渡されると SyntheticEvent が overrideConfig として
+    // requestAccessToken に流れ込むため、引数を受け取らない関数で境界を塞ぐ。
+    const authorize = React.useCallback(() => {
+        // Reauthorize ボタンのクリックは window の capture リスナも通るため、
+        // 無音更新が先に走っている場合はポップアップを二重に開かない。
+        if (renewalStateRef.current === "requesting") {
+            return;
+        }
+
+        renewalStateRef.current = "requesting";
+
+        const accountEmail = accountEmailRef.current;
+        if (accountEmail == null) {
+            // 初回はアカウントを選ばせる必要があるため、既定の prompt (select_account) に任せる。
+            requestToken();
+            return;
+        }
+
+        requestToken({ prompt: "", hint: accountEmail });
+    }, [requestToken]);
+
+    // ErdApplicationShell は React.memo でラップされており、参照が毎 render 変わると memo が素通りする。
+    // 状態遷移のときだけ参照が変わるよう固定する。
+    return React.useMemo(() => {
+        return {
+            state: authorization.state,
+            accessToken: authorization.accessToken,
+            expiresAt: authorization.expiresAt,
+            authorize
+        };
+    }, [authorization, authorize]);
+};
+
+const GDRIVE_SCOPES = [
+    "https://www.googleapis.com/auth/drive.file",
+    "https://www.googleapis.com/auth/drive.install"
+];
+
+type AuthorizationToken = {
+    state: AuthorizationState,
+    accessToken: string,
+    expiresAt: number
+};
+
+const UNAUTHORIZED_TOKEN: AuthorizationToken = { state: "unauthorized", accessToken: "", expiresAt: 0 };
+
+// idle: 次のユーザ操作で更新してよい / requesting: ポップアップの応答待ち /
+// blocked: 自動更新が失敗した。ポップアップを繰り返し開かないよう、明示操作まで再試行しない。
+type RenewalState = "idle" | "requesting" | "blocked";
+
+type AuthorizedTokenResponse = Omit<TokenResponse, "error" | "error_description" | "error_uri">;
+
+type AuthorizedArgs = {
+    setAuthorization: React.Dispatch<React.SetStateAction<AuthorizationToken>>,
+    renewalStateRef: React.RefObject<RenewalState>,
+    accountEmailRef: React.RefObject<string | null>
+};
+
+const doAuthorized = (response: AuthorizedTokenResponse, args: AuthorizedArgs): void => {
+    const hasAccess = hasGrantedAllScopesGoogle(
+        response, "https://www.googleapis.com/auth/drive.file");
+    if (hasAccess === false) {
+        // 利用者がスコープを許可しなかった場合、操作のたびにポップアップを開き直しても同じ結果になる。
+        console.warn("Not granted the drive.file scope.");
+        args.renewalStateRef.current = "blocked";
+        return;
+    }
+
+    args.renewalStateRef.current = "idle";
+
+    // 期限ぎりぎりの要求が失効済みトークンで飛ばないよう、60 秒の余裕を引いておく。
+    const expiresAt = new Date().getTime() + (response.expires_in - 60) * 1000;
+    args.setAuthorization({ state: "authorized", accessToken: response.access_token, expiresAt });
+
+    if (args.accountEmailRef.current != null) {
+        return;
+    }
+
+    // login_hint に渡すアカウントは初回だけ引く。取得できなくてもログイン中のアカウントが
+    // 1 つなら更新は成立するため、失敗しても認可自体は続行させる。
+    findAuthorizedAccount(response.access_token).then(account => {
+        args.accountEmailRef.current = account.email;
+    }).catch(error => {
+        console.warn(`Failed to find the authorized account. ${error}`);
+    });
+};
+
+type RenewOnUserGestureArgs = {
+    expiresAt: number,
+    renewalStateRef: React.RefObject<RenewalState>,
+    accountEmailRef: React.RefObject<string | null>,
+    requestToken: (overrideConfig?: OverridableTokenClientConfig) => void
+};
+
+const initRenewOnUserGesture = (args: RenewOnUserGestureArgs): ((event: Event) => void) => {
+    return (event: Event) => {
+        if (args.renewalStateRef.current !== "idle") {
+            return;
+        }
+        if (shouldRenewAccessToken(args.expiresAt, new Date().getTime()) === false) {
+            return;
+        }
+
+        // ポップアップはフォーカスを奪うため、文字入力中に開くとタイプを取りこぼす。
+        // 入力中は見送り、キャンバス操作など次の機会を待つ。
+        if (isEditingText(event.target) === true) {
+            return;
+        }
+
+        args.renewalStateRef.current = "requesting";
+
+        // await や setState を挟むと transient user activation が失われ window.open がブロックされる。
+        // 必ずリスナと同じタスクの中で同期的に要求する。
+        // hint を渡すのは、複数の Google アカウントでログイン中でもアカウント選択画面を出さないため。
+        const accountEmail = args.accountEmailRef.current;
+        const overrideConfig: OverridableTokenClientConfig = (accountEmail == null)
+            ? { prompt: "" }
+            : { prompt: "", hint: accountEmail };
+
+        args.requestToken(overrideConfig);
+    };
+};
+
+const isEditingText = (eventTarget: EventTarget | null): boolean => {
+    if (eventTarget instanceof HTMLElement) {
+        const tagName = eventTarget.tagName;
+        return (eventTarget.isContentEditable === true) || (tagName === "INPUT") || (tagName === "TEXTAREA");
+    }
+
+    return false;
+};
+
+// 期限までの残りがこの時間を切ったら、次のユーザ操作で更新を試みる。
+const RENEW_LEAD_MILLS = 10 * 60 * 1000;
+
+export const shouldRenewAccessToken = (expiresAt: number, currentTime: number): boolean => {
+    return (expiresAt - currentTime) <= RENEW_LEAD_MILLS;
+};

--- a/src/features/gdrive/gdrive-file-support.ts
+++ b/src/features/gdrive/gdrive-file-support.ts
@@ -71,6 +71,27 @@ export const findGdriveMetadata = async ({ accessToken, fileId }: OpenGdriveFile
     return { fileName: metadata.name as string, version: metadata.modifiedTime as string };
 };
 
+/**
+ * トークン更新時に login_hint として渡すアカウントを特定する。
+ * @react-oauth/google が scope へ openid/profile/email を自動付加するため、追加の同意なしに参照できる。
+ */
+export const findAuthorizedAccount = async (accessToken: string): Promise<{ email: string }> => {
+    const accountUri = "https://www.googleapis.com/oauth2/v3/userinfo";
+    const headerInfo = { headers: { Authorization: `Bearer ${accessToken}` } };
+
+    const response = await doFetchGdrive(accountUri, headerInfo);
+    if (response.ok === false) {
+        throw await toGdriveError(response, "Failed to find the authorized account.");
+    }
+
+    const account = await response.json();
+    if (("email" in account) === false) {
+        throw new Error(`Failed to find email in the account. ${JSON.stringify(account)}`);
+    }
+
+    return { email: account.email as string };
+};
+
 type CreateGdriveFileArgs = {
     accessToken: string,
     folderId: string,


### PR DESCRIPTION
The Drive app took an implicit token that expires after an hour. On expiry it
unmounted the editor and waited for the user to press "Reauthorize", which cost
a manual step every hour and discarded unsaved edits and the undo history.

GIS cannot renew silently on its own: requestAccessToken always calls
window.open, and the authorization endpoint answers with X-Frame-Options: DENY,
so the hidden-iframe renewal other OIDC libraries use cannot work against
Google. A refresh token is not an option either, since Google's token endpoint
requires a client_secret that a static site has nowhere to keep.

What is possible is a renewal that needs no user decision. Passing prompt: ""
drops the prompt parameter entirely, so an already granted, still signed-in
account gets a token back with no consent or account-chooser UI, and hint
keeps the chooser away when several accounts are signed in. The only real
constraint left is the popup blocker, so the request rides on the first click
or key press once the token is close to expiring, issued synchronously from the
listener to keep the transient user activation. Renewal is skipped while the
event target is a text field, since a popup stealing focus would drop
keystrokes.

Expiry now flips a state instead of tearing the document down. The editor stays
mounted, saving and remote sync pause, and the edits made while expired are
flushed once a token is available again - through the same update queue, so the
existing version check still catches a conflicting remote change.

Also stop handing React's SyntheticEvent to requestAccessToken: onClick={authorize}
passed the click event straight through as the overridable token config. It was
harmless only because the event happens to carry none of the keys GIS reads.

The account address used as the login hint comes from the userinfo endpoint,
which needs no new scope - @react-oauth/google already requests
openid/profile/email alongside the Drive scopes.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>